### PR TITLE
fix: adding word reset

### DIFF
--- a/src/components/features/WordsCard/WordsCard.js
+++ b/src/components/features/WordsCard/WordsCard.js
@@ -145,6 +145,8 @@ const WordsCard = ({ soundType, soundMode }) => {
     }
     setAlphabetSet(newAlphabetSet);
     setSelectiveWord(() => word(newAlphabetSet));
+    setCurrInput("");
+    hiddenInputRef.current.value = "";
   };
 
   const updateVocabSource = (source) => {


### PR DESCRIPTION
## Issue
Issue link: https://github.com/gamer-ai/eletypes-frontend/issues/76

## Description
There is an issue where the input words were not getting refreshed when we update the alphabets which results in wrong input which is already there from the new word from the new set of selected alphabets. 

## Fix
Resetting the input to `""` when we updates the selected alphabets which result in new word. 

