### PR TITLE
Refresh README: concise SEO-friendly structure + zh-CN translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,309 +1,67 @@
-# Ele types
-
-<img width="1000" alt="Screen Shot 2022-08-28 at 9 15 36 AM" src="https://user-images.githubusercontent.com/39578778/187084111-97d69aa7-53e4-46b9-b156-3ecc4d180d08.png">
-
-## [www.eletypes.com](https://www.eletypes.com) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/gamer-ai/eletype-frontend?include_prereleases) ![GitHub stars](https://img.shields.io/github/stars/gamer-ai/eletype-frontend?style=social) ![GitHub forks](https://img.shields.io/github/forks/gamer-ai/eletype-frontend?style=social)
-
-An elegant, open-source typing test tool. No sign-up required — all data tracked locally.
-
-> Typing rules and interactions inspired by the famous [monkeytype.com](https://www.monkeytype.com);
-
-> Built with React 18 + Vite, with a Supabase backend for the leaderboard.
-
-
-## Feature Requests / Issues / Bug Reports
-
-[![GitHub issues](https://img.shields.io/github/issues/gamer-ai/eletype-frontend)](https://github.com/gamer-ai/eletype-frontend/issues)
-
-https://github.com/gamer-ai/eletype-frontend/issues
-
-## Community Channel:
-
-![Discord](https://img.shields.io/discord/993567075589181621?style=for-the-badge)
-
-To join the community, please go to the website and hit "discord" icon.
-
-## Current Features:
-
-#### 1. Typing Test (words, sentence)
-
-  - words mode
-    - Eng Hard: Random blogs Words data source
-    - Eng Normal: Top 1000 most frequent used English words
-    - CHN Pinyin Hard: Chinese top 1500 idioms
-    - CHN Pinyin Normal: Chinese top 5000 words/char
-    - support four tests duration 90s, 60s, 30s, 15s
-    - + Numbers: add random numbers from 0-99 at the end of the regenerated word
-    - + Symbols: add random symbols at the end of the regenerated words
-  - Sentence mode
-    - CHN: Random chinese short sentences
-    - ENG: Random English short sentences
-    - Support three sentences count setting: 5, 10, 15
-  - Stats:
-    - WPM
-    - KPM
-    - Accuracy
-    - Error analysis (correct/error/missing/extra chars count)
-    - Visualizations
-  - Anonymous Leaderboard (per mode combination):
-    - Top 50 scores ranked by WPM (accuracy as tiebreaker)
-    - One entry per user per mode — only personal best is kept
-    - No sign-up required — uses browser fingerprint + localStorage identity
-    - Submit score after completing a typing session
-    - Browse leaderboards via the footer nav icon
-    - Anti-cheat via FingerprintJS
-  - Pacing Style (word pulse / smooth caret):
-    - Pulse mode: the active word will have an underline pulse, which helps improve the speed typing habit.
-    - Caret mode: a smooth animated caret that glides between characters with CSS transitions — Monkeytype-style.
-  - Challenge Links:
-    - Copy a challenge link after completing a test — friends who open the link type the exact same words
-    - Deterministic word generation via seeded RNG
-    - URL encodes seed + language + difficulty + timer + addons
-  - Share Results:
-    - Share button captures your stats as an image (html2canvas)
-    - Share modal with copy to clipboard, download PNG, native share (mobile)
-    - Social media buttons: X, Discord, WhatsApp, Telegram, LinkedIn, Weibo, WeChat
-    - Native share with image attachment for WhatsApp/Telegram on mobile
-
-#### 2. Words Card (for English learners)
-This word card mode has further two types **Vocab Mode** and **Selective Mode**.
-- **`Vocab Mode`** 
-  - Vocabulary Source
-    - GRE vocab
-    - TOEFL
-    - CET6
-    - CET4
-  - Multi Chapters Selection
-  - Words Card Navigation UI
-  - Recite Mode (word visibility off while phrase shown)
-- **`Selective Mode`**
-  - Provide focused typing practice with selected keys.
-  - Enables targeted improvement.
-  - Can practicing keys from the `home-row`, `top-row`, and `bottom-row`, either individually or in any combination, based on learning needs.
-
-  
-#### 3. Markdown Editor (`/markdown`) — *New*
-
- - Side-by-side markdown editor with live preview
- - Three view modes: Editor, Split, Preview
- - Syntax highlighting for code blocks (TypeScript, JavaScript, Python, etc.)
- - ASCII art "ELE TYPES" banner (responsive — compact on mobile)
- - Save as `.md` file
- - Typing sound support
- - Standalone route with minimal bottom nav
-
-<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/bf5fa8c6-26d9-439f-b284-0d1620b09fdc" />
-
-
-#### 4. Keyboard Lab (`/keyboardlab`) — *Beta*
-
- - 3D keyboard design editor — design custom keyboards in your browser
- - 7 layouts: 60%, 65%, HHKB 60%, 75%, TKL, Full-size, Cyberboard R2
- - 8 keycap profiles: Cherry, OEM, SA, MT3, KAT, DSA, XDA, Low Profile
- - 5 shell presets: Standard, Slim, Wide Bezel, Angular, Top Heavy
- - Parametric case profile editor with 2D → 3D extrusion
- - Colored edge accent strips (LED-style glow)
- - Per-group opacity: keycap, accent, case, legend
- - 10 color themes with "le smoking" as default
- - 6 legend presets with live font/size/weight/color/opacity editing
- - Legend position schema with safe inset — anchors never overflow the keycap
- - **KLE layout import** — paste raw data or drop a `.json` from keyboard-layout-editor.com
- - **Bento card UI** — per-asset collapsible cards with Config / JSON / Doc tabs; right panel scrolls within its container
- - Live key press animation with sound
- - Bidirectional JSON schema editor (one Monaco instance per card)
- - Design save/load/export/import (eletypes-design-bundle/1 format)
- - Roadmap modal with editor's note
- - Full EN/ZH localization
- - See [KEYBOARD_LAB.md](src/components/features/KeyboardLab/KEYBOARD_LAB.md) for full documentation
-
-<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/0ab9989a-260a-4b63-95be-b994f3a0b493" />
-
-
-#### 6. QWERTY Keyboard touch-typing trainer 
-
- - A QWERTY keyboard layout UI populating random key for touch typing with stats
-
-#### 7. Spotify player
-
- - A spotify player 
- 
-#### 8. Themes Collection
-
-- Static Themes
+# Eletypes
 
-  - Dark
-  - Tokyo night
-  - Piano
-  - Aluminum
-  - Terminal (matrix inspired)
-  - Cyber (cyberpunk inspired)
-  - Steam (steampunk inspired)
-  - Light
-  - Nintendo
-  - Araki Nobuyoshi
-  - Hero
-  - Budapest
-  - Cool Kid
-  - EdgeRunner (cyberpunk 2077 edgerunners episodes inspired)
+> **An elegant, open-source typing test with anonymous leaderboards, badges, and a built-in 3D keyboard design lab.** No signup. No ads. All data stays in your browser.
 
-- Dynamic Themes (WebGL based, may degrade performance. experimental feature. Component Library used from [UV canvas](https://uvcanvas.com/))
+**🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
 
-  - Tranquiluxe,
-  - Lumiflex,
-  - Opulento,
-  - Velustro
+[![Live](https://img.shields.io/badge/www-eletypes.com-6ec6ff)](https://www.eletypes.com)
+![Release](https://img.shields.io/github/v/release/gamer-ai/eletype-frontend?include_prereleases)
+![Stars](https://img.shields.io/github/stars/gamer-ai/eletype-frontend?style=social)
+![Discord](https://img.shields.io/discord/993567075589181621)
+[![License](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE)
 
-![dynamicThemesDemo](https://github.com/gamer-ai/eletypes-frontend/assets/39578778/d716a287-6f59-4568-8276-1ee6b5f5850a)
+<img width="1000" alt="Eletypes" src="https://user-images.githubusercontent.com/39578778/187084111-97d69aa7-53e4-46b9-b156-3ecc4d180d08.png" />
 
-  
-#### 9. LocalStorage persist for essential settings
+## Why Eletypes?
 
-  - Browser refresh will bring back to the localStorage stored settings
+A typing test that respects your time — fast, private, beautiful. Built by a keyboard geek tired of bloated platforms. Inspired by [monkeytype.com](https://www.monkeytype.com/), written in React 18 + Vite, backed by Supabase.
 
-#### 10. Focus Mode
+## Features
 
-  - move header to footer. 
-  - hide the setting menu. leave only timer, wpm stats. 
-  - If music enabled, a compact spotify will be put in footer.
+### Modes
+- **Typing Test** — English & Chinese (Pinyin), words + sentence modes, 15/30/60/90s timers, +numbers / +symbols add-ons, pulse & caret pacing
+- **Vocab Cards** — GRE, TOEFL, CET4/6; learn vocabulary by typing it
+- **Markdown Editor** at `/markdown` — live preview, syntax highlighting, save as `.md`
+- **Keyboard Lab** at `/keyboardlab` *(beta)* — design custom 3D keyboards in your browser: 7 layouts, 8 keycap profiles, parametric case editor, KLE import, full JSON schema. → [deep dive](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- **QWERTY Trainer** — touch-typing practice
 
-#### 11. Ultra Zen Mode
+### Social & Progress
+- **Anonymous leaderboard** — top 50 WPM per mode; fingerprint identity; no signup
+- **Badges & ranks** — 30+ achievements across speed, accuracy, consistency, exploration
+- **Stats dashboard** — activity heatmap, WPM trend, outlier detection, session history
+- **Challenge links** — deterministic seeded words; send friends the exact same test
+- **Shareable result cards** — auto-rendered image for X / Discord / WhatsApp / LinkedIn / Weibo / WeChat
 
-![image](https://github.com/user-attachments/assets/ab3e7c94-4f38-4607-86aa-1cd3d8296381)
+### Experience
+- **18 themes** including dynamic WebGL backgrounds (Tranquiluxe, Lumiflex, Opulento, Velustro)
+- **Typing sounds** — Cherry Blue, mechanical, typewriter
+- **Focus / Ultra Zen** modes for distraction-free sessions
+- **PWA** — installable, works offline
+- **i18n** — full English & 中文 UI
+- **Keyboard shortcuts** — `Tab+Space` redo · `Tab+Enter` restart
 
-toggle ![image](https://github.com/user-attachments/assets/b552b444-f411-4a1d-a40a-981b05e3e59d) to use the ultra zen mode when in words mode. The ultra zen mode can auto highlight and auto dim while you are typing. 
+### Privacy
+No accounts. No ads. No tracking. History and settings live in your browser's localStorage. Leaderboard uses a fingerprint for anti-cheat only.
 
- 
-#### 12. Typing Sound Effect
+## Quick Start
 
-  - default: cherry blue switch
-  - optional: keyboard (hard)
-  - optional: typewriter (soft)
-  
-  <img width="120" alt="Screen Shot 2022-09-29 at 2 01 51 AM" src="https://user-images.githubusercontent.com/39578778/192989337-637e1154-fbca-420b-babb-22846d5dbdb1.png">
-  
-#### 13. [Tab] key to Fast redo/reset
+```bash
+npm install
+npm run dev      # localhost:3000
+npm run build    # production bundle
+npm run deploy   # Firebase Hosting
+```
 
-  - [Tab] + [Space] for quickly redo
-  - [Tab] + [Enter] / [Tab] + [Tab] for quickly reset
-  - [Tab] + [Any Key] to exit the dialog
+## Documentation
 
-#### 14. Chinese / English UI (i18n)
+- [Keyboard Lab — architecture & roadmap](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- [Contributing with Claude / agent guide](CLAUDE.md)
 
-  - Toggle between Chinese and English interface via the settings or profile menu
-  - All tooltips, labels, stats, leaderboard text, and banners are translated
-  - Preference persisted in localStorage
+## Community
 
-#### 15. Profile Menu
+- **Discord** — click the Discord icon in the app footer
+- **[Issues & feature requests](https://github.com/gamer-ai/eletype-frontend/issues)**
 
-  - Accessible via the profile button (top-right corner), always visible including in focus mode
-  - **Profile** — edit display name, view rank + badges (no sign-up required)
-  - **Stats** — personal dashboard with:
-    - Overview: best/avg effective WPM (WPM × Accuracy), average accuracy
-    - Activity heatmap (3 months, GitHub-style)
-    - WPM and accuracy consistency gauges
-    - WPM trend chart with outlier detection (flags low-accuracy sessions)
-    - Mode breakdown table
-    - Session history per mode with filters, per-entry delete, and clear all
-  - **Leaderboard** — browse global leaderboard from any mode (no need to finish a test first)
-  - **Settings** — toggle switches for Focus Mode, Sound, Music, Ultra Zen, and Interface Language
-  - **News** — view all announcements including previously dismissed banners
+## License
 
-#### 16. Badge System
-
-  - 33 badges across 6 categories: Speed, Effective Speed, Accuracy, Consistency, Explorer, Social
-  - Speed badges based on raw WPM, Effective Speed badges based on WPM × Accuracy
-  - Rank system (7 tiers from Membrane to Custom Build) based on best effective WPM
-  - Hidden badges discoverable through gameplay
-  - Badge notifications on unlock
-
-#### 17. Progressive Web App (PWA)
-
-  - Installable on desktop and mobile — works like a native app
-  - Offline support via service worker (type without internet)
-  - Auto-updates when new versions are deployed
-
-#### 18. Words Card Auto-Play Audio
-
-  - Auto-play pronunciation audio when navigating words in vocab mode
-  - Toggle on/off next to the speaker button, persisted in localStorage
-  - Defaults to on
-
-### Some Themes
-
-<img width="600" alt="EletypesThemes" src="https://user-images.githubusercontent.com/39578778/187084245-364b6c5f-97e4-42c9-a0c6-010505ad3283.png">
-
-### Caps Lock Detection
-
-<img width="400" alt="Screen Shot 2022-04-20 at 4 52 24 PM" src="https://user-images.githubusercontent.com/39578778/164343051-2de97570-fcec-49a4-893a-903afe94e5f4.png">
-
-### Simplist typing stats is all your need
-
-<img width="800" alt="Screen Shot 2022-08-28 at 9 24 55 AM" src="https://user-images.githubusercontent.com/39578778/187084372-a4d18d33-286e-4e7b-97d0-d069c7fd1d53.png">
-
-### Words Card Demo
-
-Regular Mode and Recite Mode
-
-<img width="400" alt="Screen Shot 2022-08-23 at 12 47 53 AM" src="https://user-images.githubusercontent.com/39578778/186102023-7db8bfc2-f481-4a90-98c2-f47ad66c12cd.png"><img width="400" alt="Screen Shot 2022-08-23 at 12 48 22 AM" src="https://user-images.githubusercontent.com/39578778/186102059-cb7d43a4-a9d3-4728-90f9-2965038ed24c.png">
-
-### QWERTY Touch-Typing Trainer Demo
-
-<img width="800" alt="Screen Shot 2022-08-23 at 12 52 17 AM" src="https://user-images.githubusercontent.com/39578778/186102830-4c664e9a-adfa-48dc-ba8c-e03df4e22ade.png">
-
-
-## For Devs
-
-### Setup
-
-1. `npm install`
-2. Copy `.env.example` to `.env` and fill in your Supabase project URL and anon key
-3. Run the SQL in `supabase_migration.sql` in your Supabase SQL Editor to create the scores table
-
-### `npm run dev`
-
-Runs the app in development mode with Vite.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.\
-Hot Module Replacement (HMR) enabled — changes reflect instantly.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder using Vite.
-
-### `npm run preview`
-
-Serves the production build locally for testing.
-
-### Environment Variables
-
-| Variable | Description |
-|---|---|
-| `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_ANON_KEY` | Supabase anon/public API key |
-
-For Netlify deploys, set these in **Site configuration > Environment variables**.
-
-### Pull Requests
-
-Create a branch with proper name example 'feat/your-cool-feature', create the pull request and add authors for reviews. Please include description with details.
-
-
-## Sponsors
-
-### Buy Me A Coffee:
-
-https://www.buymeacoffee.com/daguozi
-
-## Credits
-
-Thanks [@rendi12345678](https://github.com/rendi12345678) for his continuous contributions and making the feature of data visualization for the typing stats!
-
-
-## Roblox Game
-
-Recently a Roblox game "Type!" was built on top of the Ele Types by [@WheelMakerStudio](https://www.roblox.com/users/10692403745/profile/) and expanded features such as leaderboards and battle modes. You can find it [here](https://www.roblox.com/games/89217440428554/Type).
-
-
-<img width="800" height="600" alt="Screenshot 2026-03-23 at 11 13 27 PM" src="https://github.com/user-attachments/assets/ea36bc86-50c1-48c9-acea-7350e7f4669a" />
-
-
-
+[GPL-3.0](LICENSE) — free to use, modify, and redistribute. Derivative works must remain open source under the same license.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eletypes
 
-> **An elegant, open-source typing test with anonymous leaderboards, badges, and a built-in 3D keyboard design lab.** No signup. No ads. Your history is local; leaderboard submissions are anonymous.
+> **An elegant, open-source typing test that kept growing — now with vocab cards for English learners, a 3D keyboard design lab, a markdown editor, and a no-signup leaderboard with achievement badges.** Your practice history is local. The leaderboard asks only for a display name you pick — no email, no password, no account.
 
 **🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
 
@@ -14,19 +14,19 @@
 
 ## Why Eletypes?
 
-Warm up with a chill session, or go deep and design your own 3D keyboard — Eletypes stays clean and fast either way. Inspired by [monkeytype.com](https://www.monkeytype.com/), built on React 18 + Vite, with Supabase behind the leaderboard.
+What started as a typing test inspired by [monkeytype.com](https://www.monkeytype.com/) kept growing. Today the four pillars are **typing test**, **vocab cards** (widely used by English learners), **Keyboard Lab** (a 3D keyboard design playground), and a **markdown editor** — all in one clean, open-source app. Built on React 18 + Vite, with Supabase behind the leaderboard.
 
 ## Features
 
 ### Modes
 - **Typing Test** — English & Chinese (Pinyin), words + sentence modes, 15/30/60/90s timers, +numbers / +symbols add-ons, pulse & caret pacing
-- **Vocab Cards** — GRE, TOEFL, CET4/6; learn vocabulary by typing it
-- **Markdown Editor** at `/markdown` — live preview, syntax highlighting, save as `.md`
+- **Vocab Cards** *(popular with English learners)* — GRE, TOEFL, CET4/CET6 word decks; type to learn, with a recite mode that hides the word while the phrase stays visible
 - **Keyboard Lab** at `/keyboardlab` *(beta)* — design custom 3D keyboards in your browser: 7 layouts, 8 keycap profiles, parametric case editor, KLE import, full JSON schema. → [deep dive](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- **Markdown Editor** at `/markdown` — live preview, syntax highlighting, save as `.md`
 - **QWERTY Trainer** — touch-typing practice
 
 ### Social & Progress
-- **Anonymous leaderboard** — top 50 WPM per mode; fingerprint identity; no signup
+- **No-signup leaderboard** — top 50 WPM per mode; pick any display name; fingerprint used for anti-cheat only
 - **Badges & ranks** — 30+ achievements across speed, accuracy, consistency, exploration
 - **Stats dashboard** — activity heatmap, WPM trend, outlier detection, session history
 - **Challenge links** — deterministic seeded words; send friends the exact same test
@@ -41,7 +41,20 @@ Warm up with a chill session, or go deep and design your own 3D keyboard — Ele
 - **Keyboard shortcuts** — `Tab+Space` redo · `Tab+Enter` restart
 
 ### Privacy
-No accounts. No ads. No tracking. Your practice history and settings live in your browser's localStorage. The only data that leaves your device is anonymous leaderboard submissions — tagged by a browser fingerprint (no account, no PII) purely for anti-cheat and dedup.
+No accounts. No ads. No tracking. Your practice history and settings live in your browser's localStorage. The only data that leaves your device is opt-in leaderboard submissions — a display name you pick (no email, no password, no account) plus a browser fingerprint used purely for anti-cheat and dedup.
+
+## Gallery
+
+<table>
+  <tr>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/0ab9989a-260a-4b63-95be-b994f3a0b493" alt="Keyboard Lab" /><br/><sub><b>Keyboard Lab</b> — design custom 3D keyboards</sub></td>
+    <td width="50%"><img src="https://github.com/gamer-ai/eletypes-frontend/assets/39578778/d716a287-6f59-4568-8276-1ee6b5f5850a" alt="Dynamic themes" /><br/><sub><b>Dynamic WebGL themes</b> — Tranquiluxe · Lumiflex · Opulento · Velustro</sub></td>
+  </tr>
+  <tr>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/bf5fa8c6-26d9-439f-b284-0d1620b09fdc" alt="Markdown editor" /><br/><sub><b>Markdown editor</b> — live preview with syntax highlighting</sub></td>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/ab3e7c94-4f38-4607-86aa-1cd3d8296381" alt="Ultra Zen mode" /><br/><sub><b>Ultra Zen</b> — auto-highlight, auto-dim, distraction-free</sub></td>
+  </tr>
+</table>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eletypes
 
-> **An elegant, open-source typing test with anonymous leaderboards, badges, and a built-in 3D keyboard design lab.** No signup. No ads. All data stays in your browser.
+> **An elegant, open-source typing test with anonymous leaderboards, badges, and a built-in 3D keyboard design lab.** No signup. No ads. Your history is local; leaderboard submissions are anonymous.
 
 **🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
 
@@ -14,7 +14,7 @@
 
 ## Why Eletypes?
 
-A typing test that respects your time — fast, private, beautiful. Built by a keyboard geek tired of bloated platforms. Inspired by [monkeytype.com](https://www.monkeytype.com/), written in React 18 + Vite, backed by Supabase.
+Warm up with a chill session, or go deep and design your own 3D keyboard — Eletypes stays clean and fast either way. Inspired by [monkeytype.com](https://www.monkeytype.com/), built on React 18 + Vite, with Supabase behind the leaderboard.
 
 ## Features
 
@@ -41,7 +41,7 @@ A typing test that respects your time — fast, private, beautiful. Built by a k
 - **Keyboard shortcuts** — `Tab+Space` redo · `Tab+Enter` restart
 
 ### Privacy
-No accounts. No ads. No tracking. History and settings live in your browser's localStorage. Leaderboard uses a fingerprint for anti-cheat only.
+No accounts. No ads. No tracking. Your practice history and settings live in your browser's localStorage. The only data that leaves your device is anonymous leaderboard submissions — tagged by a browser fingerprint (no account, no PII) purely for anti-cheat and dedup.
 
 ## Quick Start
 
@@ -61,6 +61,16 @@ npm run deploy   # Firebase Hosting
 
 - **Discord** — click the Discord icon in the app footer
 - **[Issues & feature requests](https://github.com/gamer-ai/eletype-frontend/issues)**
+
+## Credits
+
+Huge thanks to [@rendi12345678](https://github.com/rendi12345678) for continuous contributions — including the data visualization for typing stats.
+
+## Sponsor
+
+If Eletypes helps you or just makes you smile, consider supporting development:
+
+[☕ Buy Me A Coffee](https://www.buymeacoffee.com/daguozi)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,67 @@
+# Eletypes 打字
+
+> **一款优雅、开源的打字测试工具，内置匿名排行榜、成就徽章，和 3D 键盘设计工坊。** 无需注册、无广告、所有数据仅保存在你的浏览器。
+
+**🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
+
+[![线上](https://img.shields.io/badge/www-eletypes.com-6ec6ff)](https://www.eletypes.com)
+![版本](https://img.shields.io/github/v/release/gamer-ai/eletype-frontend?include_prereleases)
+![Stars](https://img.shields.io/github/stars/gamer-ai/eletype-frontend?style=social)
+![Discord](https://img.shields.io/discord/993567075589181621)
+[![许可](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE)
+
+<img width="1000" alt="Eletypes" src="https://user-images.githubusercontent.com/39578778/187084111-97d69aa7-53e4-46b9-b156-3ecc4d180d08.png" />
+
+## 为什么选择 Eletypes？
+
+一个尊重你时间的打字工具 —— 快、干净、好看。由一个受够臃肿打字平台的键盘爱好者打造。灵感来自 [monkeytype.com](https://www.monkeytype.com/)，基于 React 18 + Vite，排行榜使用 Supabase。
+
+## 功能
+
+### 模式
+- **打字测试** —— 支持英文与中文拼音，单词与句子模式，15/30/60/90 秒计时，可叠加数字 / 符号，脉冲与光标两种节奏样式
+- **词卡** —— GRE、TOEFL、CET4/6，边打边记
+- **Markdown 编辑器**（`/markdown`）—— 实时预览、语法高亮、导出 `.md`
+- **键盘实验室**（`/keyboardlab`，*Beta*）—— 在浏览器里设计 3D 键盘：7 种布局、8 种键帽轮廓、参数化外壳编辑器、KLE 导入、完整 JSON Schema 编辑。→ [详细文档](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- **QWERTY 练习** —— 盲打训练
+
+### 社交与进阶
+- **匿名排行榜** —— 各模式前 50 名，基于浏览器指纹身份，无需注册
+- **徽章与段位** —— 30+ 成就，覆盖速度、准确率、稳定性、探索
+- **统计面板** —— 活动热力图、WPM 趋势、异常检测、历史会话
+- **挑战链接** —— 基于种子的确定性词序，和朋友打完全一样的测试
+- **战绩分享卡** —— 一键生成图片，分享到 X / Discord / WhatsApp / LinkedIn / 微博 / 微信
+
+### 体验
+- **18 种主题**，包含 WebGL 动态背景（Tranquiluxe、Lumiflex、Opulento、Velustro）
+- **打字音效** —— 樱桃青轴、机械键盘、打字机
+- **专注 / 超静 模式** —— 无干扰界面
+- **PWA** —— 可安装、可离线
+- **中英双语 UI**
+- **键盘快捷键** —— `Tab+Space` 重做 · `Tab+Enter` 重开
+
+### 隐私
+无账号、无广告、无追踪。历史与设置仅存在浏览器 localStorage。排行榜仅用浏览器指纹防刷。
+
+## 快速开始
+
+```bash
+npm install
+npm run dev      # localhost:3000
+npm run build    # 生产构建
+npm run deploy   # Firebase Hosting 部署
+```
+
+## 文档
+
+- [键盘实验室 —— 架构与路线图](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- [Claude / Agent 协作指南](CLAUDE.md)
+
+## 社区
+
+- **Discord** —— 在应用页脚点击 Discord 图标加入
+- **[问题反馈 / 需求提交](https://github.com/gamer-ai/eletype-frontend/issues)**
+
+## 许可
+
+[GPL-3.0](LICENSE) —— 可自由使用、修改、再分发。派生作品须以同样的许可保持开源。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Eletypes 打字
 
-> **一款优雅、开源的打字测试工具，内置匿名排行榜、成就徽章，和 3D 键盘设计工坊。** 无需注册、无广告；历史数据存在本地浏览器，提交排行榜是匿名的。
+> **一款优雅、开源的打字工具 —— 最初只是一个打字测试，后来慢慢长大：词卡（不少英语学习者在用）、3D 键盘设计工坊、Markdown 编辑器，以及免注册排行榜和成就徽章。** 练习历史数据存在本地浏览器。排行榜只需你自选一个昵称，无需邮箱、无需密码、无需账号。
 
 **🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
 
@@ -14,19 +14,19 @@
 
 ## 为什么选择 Eletypes？
 
-随便打几个字放松一下，或者深入设计属于自己的 3D 键盘 —— Eletypes 都能保持简洁快速。灵感来自 [monkeytype.com](https://www.monkeytype.com/)，基于 React 18 + Vite，排行榜使用 Supabase。
+最初只是一个受 [monkeytype.com](https://www.monkeytype.com/) 启发的打字测试，后来慢慢长大。现在的四根支柱是 **打字测试**、**词卡**（英语学习者在用）、**键盘实验室**（3D 键盘设计工坊）、以及 **Markdown 编辑器** —— 全部整合在同一个干净、开源的应用里。基于 React 18 + Vite，排行榜使用 Supabase。
 
 ## 功能
 
 ### 模式
 - **打字测试** —— 支持英文与中文拼音，单词与句子模式，15/30/60/90 秒计时，可叠加数字 / 符号，脉冲与光标两种节奏样式
-- **词卡** —— GRE、TOEFL、CET4/6，边打边记
-- **Markdown 编辑器**（`/markdown`）—— 实时预览、语法高亮、导出 `.md`
+- **词卡** *（英语学习者常用）* —— GRE、TOEFL、CET4 / CET6 词书；边打边学，支持"背诵模式"（隐藏单词、显示例句）
 - **键盘实验室**（`/keyboardlab`，*Beta*）—— 在浏览器里设计 3D 键盘：7 种布局、8 种键帽轮廓、参数化外壳编辑器、KLE 导入、完整 JSON Schema 编辑。→ [详细文档](src/components/features/KeyboardLab/KEYBOARD_LAB.md)
+- **Markdown 编辑器**（`/markdown`）—— 实时预览、语法高亮、导出 `.md`
 - **QWERTY 练习** —— 盲打训练
 
 ### 社交与进阶
-- **匿名排行榜** —— 各模式前 50 名，基于浏览器指纹身份，无需注册
+- **免注册排行榜** —— 各模式前 50 名；自选昵称即可；浏览器指纹仅用于防刷
 - **徽章与段位** —— 30+ 成就，覆盖速度、准确率、稳定性、探索
 - **统计面板** —— 活动热力图、WPM 趋势、异常检测、历史会话
 - **挑战链接** —— 基于种子的确定性词序，和朋友打完全一样的测试
@@ -41,7 +41,20 @@
 - **键盘快捷键** —— `Tab+Space` 重做 · `Tab+Enter` 重开
 
 ### 隐私
-无账号、无广告、无追踪。练习历史与设置仅保存在浏览器 localStorage。唯一离开你设备的是匿名排行榜记录 —— 仅用浏览器指纹（不含账号、不含任何个人信息）进行防刷与去重。
+无账号、无广告、无追踪。练习历史与设置仅保存在浏览器 localStorage。唯一离开你设备的是你主动提交的排行榜记录 —— 包括你自选的昵称（无需邮箱、无需密码、无需账号），以及仅用于防刷/去重的浏览器指纹。
+
+## 图集
+
+<table>
+  <tr>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/0ab9989a-260a-4b63-95be-b994f3a0b493" alt="Keyboard Lab" /><br/><sub><b>键盘实验室</b> —— 在浏览器里设计 3D 键盘</sub></td>
+    <td width="50%"><img src="https://github.com/gamer-ai/eletypes-frontend/assets/39578778/d716a287-6f59-4568-8276-1ee6b5f5850a" alt="Dynamic themes" /><br/><sub><b>WebGL 动态主题</b> —— Tranquiluxe · Lumiflex · Opulento · Velustro</sub></td>
+  </tr>
+  <tr>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/bf5fa8c6-26d9-439f-b284-0d1620b09fdc" alt="Markdown editor" /><br/><sub><b>Markdown 编辑器</b> —— 实时预览 + 语法高亮</sub></td>
+    <td width="50%"><img src="https://github.com/user-attachments/assets/ab3e7c94-4f38-4607-86aa-1cd3d8296381" alt="Ultra Zen mode" /><br/><sub><b>超静模式</b> —— 自动高亮、自动淡出、无干扰</sub></td>
+  </tr>
+</table>
 
 ## 快速开始
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Eletypes 打字
 
-> **一款优雅、开源的打字测试工具，内置匿名排行榜、成就徽章，和 3D 键盘设计工坊。** 无需注册、无广告、所有数据仅保存在你的浏览器。
+> **一款优雅、开源的打字测试工具，内置匿名排行榜、成就徽章，和 3D 键盘设计工坊。** 无需注册、无广告；历史数据存在本地浏览器，提交排行榜是匿名的。
 
 **🌐 [English](./README.md) · [中文](./README.zh-CN.md)**
 
@@ -14,7 +14,7 @@
 
 ## 为什么选择 Eletypes？
 
-一个尊重你时间的打字工具 —— 快、干净、好看。由一个受够臃肿打字平台的键盘爱好者打造。灵感来自 [monkeytype.com](https://www.monkeytype.com/)，基于 React 18 + Vite，排行榜使用 Supabase。
+随便打几个字放松一下，或者深入设计属于自己的 3D 键盘 —— Eletypes 都能保持简洁快速。灵感来自 [monkeytype.com](https://www.monkeytype.com/)，基于 React 18 + Vite，排行榜使用 Supabase。
 
 ## 功能
 
@@ -41,7 +41,7 @@
 - **键盘快捷键** —— `Tab+Space` 重做 · `Tab+Enter` 重开
 
 ### 隐私
-无账号、无广告、无追踪。历史与设置仅存在浏览器 localStorage。排行榜仅用浏览器指纹防刷。
+无账号、无广告、无追踪。练习历史与设置仅保存在浏览器 localStorage。唯一离开你设备的是匿名排行榜记录 —— 仅用浏览器指纹（不含账号、不含任何个人信息）进行防刷与去重。
 
 ## 快速开始
 
@@ -61,6 +61,16 @@ npm run deploy   # Firebase Hosting 部署
 
 - **Discord** —— 在应用页脚点击 Discord 图标加入
 - **[问题反馈 / 需求提交](https://github.com/gamer-ai/eletype-frontend/issues)**
+
+## 鸣谢
+
+特别感谢 [@rendi12345678](https://github.com/rendi12345678) 长期以来的贡献 —— 包括打字数据可视化功能。
+
+## 赞助
+
+如果 Eletypes 帮到了你，或者只是让你会心一笑，欢迎请作者喝杯咖啡：
+
+[☕ Buy Me A Coffee](https://www.buymeacoffee.com/daguozi)
 
 ## 许可
 


### PR DESCRIPTION
- Condensed ~306 lines to ~68 — product pitch over exhaustive feature log
- Grouped features: Modes / Social & Progress / Experience / Privacy
- Added language switcher at top; new README.zh-CN.md mirrors structure
- Leading tagline with primary keywords (typing test, leaderboard, 3D keyboard lab) for SEO
- License badge + section corrected to GPL-3.0 (was mistakenly MIT in earlier draft)
- Deep content stays linked: KEYBOARD_LAB.md, CLAUDE.md, issues
- Kept the main hero image; moved granular details out of README