### PR TITLE
Keyboard Lab: CSG-carved cutouts + per-key LED backlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "seedrandom": "^3.0.5",
         "styled-components": "^5.3.5",
         "three": "^0.160.0",
+        "three-bvh-csg": "^0.0.17",
         "use-sound": "^4.0.1",
         "uvcanvas": "^0.2.1",
         "vite-plugin-pwa": "^1.2.0",
@@ -8219,6 +8220,15 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
       "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
     },
+    "node_modules/three-bvh-csg": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/three-bvh-csg/-/three-bvh-csg-0.0.17.tgz",
+      "integrity": "sha512-iEkHDF8GRfGM6593Cuw8SnF1vfENCp46gIAtRzuL4nGXGWPcR1sbTBwM9ptDONb5twqlZp5WkAKya5aBKe2qcA==",
+      "peerDependencies": {
+        "three": ">=0.151.0",
+        "three-mesh-bvh": ">=0.6.6"
+      }
+    },
     "node_modules/three-mesh-bvh": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.6.8.tgz",
@@ -14703,6 +14713,12 @@
       "version": "0.160.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
       "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
+    },
+    "three-bvh-csg": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/three-bvh-csg/-/three-bvh-csg-0.0.17.tgz",
+      "integrity": "sha512-iEkHDF8GRfGM6593Cuw8SnF1vfENCp46gIAtRzuL4nGXGWPcR1sbTBwM9ptDONb5twqlZp5WkAKya5aBKe2qcA==",
+      "requires": {}
     },
     "three-mesh-bvh": {
       "version": "0.6.8",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "seedrandom": "^3.0.5",
     "styled-components": "^5.3.5",
     "three": "^0.160.0",
+    "three-bvh-csg": "^0.0.17",
     "use-sound": "^4.0.1",
     "uvcanvas": "^0.2.1",
     "vite-plugin-pwa": "^1.2.0",

--- a/src/components/features/KeyboardLab/CaseEditor/CaseProfileEditor.jsx
+++ b/src/components/features/KeyboardLab/CaseEditor/CaseProfileEditor.jsx
@@ -69,21 +69,37 @@ const CaseProfileEditor = ({ theme, onChange, initialProfile, extrudeWidth, onEx
   const [points, setPoints] = useState(initialProfile?.points || PROFILE_PRESETS.wedge.points);
   const [mountEdge, setMountEdge] = useState(initialProfile?.mountEdge || PROFILE_PRESETS.wedge.mountEdge);
   const [coloredEdges, setColoredEdges] = useState(initialProfile?.coloredEdges || []);
+  // Pass-through: editor doesn't expose UI for topFrame yet, but it must
+  // preserve the field so it survives the onChange round-trip — otherwise
+  // the resolved profile's cutouts get silently stripped on every edit.
+  const [topFrame, setTopFrame] = useState(initialProfile?.topFrame || null);
   const [dragging, setDragging] = useState(null);
   const [selectedPoint, setSelectedPoint] = useState(null);
   const [hoveredPoint, setHoveredPoint] = useState(null);
   const [hoveredEdge, setHoveredEdge] = useState(null);
 
-  // Sync from parent when initialProfile changes (e.g., loading a saved design)
+  // Sync from parent when initialProfile changes (e.g., loading a saved design).
+  // Hash the WHOLE profile, not just points — otherwise async-loaded topFrame
+  // / coloredEdges arrive with the same points, the sync skips, and the
+  // editor's emit-effect immediately strips the new fields with its stale
+  // local state. Whole-profile hashing still breaks the user-edit loop
+  // because after the editor emits, parent's profile === editor's local
+  // state, so the hash matches and we don't re-sync.
   const lastLoadedRef = useRef(null);
   useEffect(() => {
     if (!initialProfile?.points) return;
-    const key = JSON.stringify(initialProfile.points);
+    const key = JSON.stringify({
+      points: initialProfile.points,
+      mountEdge: initialProfile.mountEdge,
+      coloredEdges: initialProfile.coloredEdges,
+      topFrame: initialProfile.topFrame,
+    });
     if (key !== lastLoadedRef.current) {
       lastLoadedRef.current = key;
       setPoints(initialProfile.points.map(p => ({ ...p })));
       if (initialProfile.mountEdge) setMountEdge([...initialProfile.mountEdge]);
       setColoredEdges(initialProfile.coloredEdges || []);
+      setTopFrame(initialProfile.topFrame || null);
       setSelectedPoint(null);
     }
   }, [initialProfile]);
@@ -121,8 +137,12 @@ const CaseProfileEditor = ({ theme, onChange, initialProfile, extrudeWidth, onEx
 
   // Emit profile changes
   useEffect(() => {
-    if (onChange) onChange({ points, mountEdge, coloredEdges });
-  }, [points, mountEdge, coloredEdges, onChange]);
+    if (onChange) {
+      const next = { points, mountEdge, coloredEdges };
+      if (topFrame) next.topFrame = topFrame;
+      onChange(next);
+    }
+  }, [points, mountEdge, coloredEdges, topFrame, onChange]);
 
 
   // ─── Drag handling ───

--- a/src/components/features/KeyboardLab/CaseEditor/carveTopCSG.js
+++ b/src/components/features/KeyboardLab/CaseEditor/carveTopCSG.js
@@ -1,0 +1,340 @@
+/**
+ * carveTopCSG — boolean-subtract shallow grooves from the case body.
+ *
+ * Approach: compute cutout volumes (box brushes) in world space aligned to
+ * the mount-edge surface, then run three-bvh-csg SUBTRACTION against the
+ * already-extruded case body geometry. Result: ONE mesh with cavities
+ * baked into it — no plate-on-top, no z-fighting.
+ *
+ * Two cutout modes:
+ *   - "plate": one switch-sized cavity per key (cap minus uniform border)
+ *   - "tray":  one rectangular cavity per group (cluster bbox + borderWidth)
+ *
+ * Grouping (tray-only):
+ *   - "all":         single bbox around every key
+ *   - "per-row":     adjacency-clustered Y bands → bbox per row
+ *   - "per-cluster": connected components in XY → bbox per cluster
+ *
+ * Wedge support: every subtractor is oriented to the mount-edge plane via
+ * a 4×4 matrix (X stays world X; local Y = outward normal Nout; local Z =
+ * tangent T from front to back). For flat profiles this collapses to a
+ * straight axis-aligned box. For tilted profiles the box rotates with the
+ * surface so the cut depth is uniform across the slope.
+ */
+
+import * as THREE from "three";
+import { Brush, Evaluator, SUBTRACTION } from "three-bvh-csg";
+import { mergeVertices, mergeBufferGeometries } from "three-stdlib";
+
+const ADJACENCY_GAP = 0.5;   // u — keys closer than this count as same cluster
+const ROW_GAP       = 0.5;   // u — y values closer than this count as same row
+
+// ─── Clustering ───────────────────────────────────────────────────────
+
+/** Group keys by row using gap-based 1D clustering on key.y. */
+const clusterByRow = (keys) => {
+  const sorted = [...keys].sort((a, b) => a.y - b.y);
+  const rows = [];
+  let current = [];
+  let lastY = -Infinity;
+  for (const k of sorted) {
+    if (k.y - lastY > ROW_GAP && current.length > 0) {
+      rows.push(current);
+      current = [];
+    }
+    current.push(k);
+    lastY = Math.max(lastY, k.y);
+  }
+  if (current.length) rows.push(current);
+  return rows;
+};
+
+/** Union-find: cluster keys whose bboxes are within ADJACENCY_GAP of each other. */
+const clusterByAdjacency = (keys) => {
+  const n = keys.length;
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const find = (i) => parent[i] === i ? i : (parent[i] = find(parent[i]));
+  const union = (a, b) => { const ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb; };
+
+  const bbox = (k) => ({
+    minX: k.x, maxX: k.x + (k.w || 1),
+    minY: k.y, maxY: k.y + (k.h || 1),
+  });
+  const gap = (a, b) => {
+    const ba = bbox(a), bb = bbox(b);
+    const gx = Math.max(0, Math.max(ba.minX - bb.maxX, bb.minX - ba.maxX));
+    const gy = Math.max(0, Math.max(ba.minY - bb.maxY, bb.minY - ba.maxY));
+    return Math.hypot(gx, gy);
+  };
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (gap(keys[i], keys[j]) <= ADJACENCY_GAP) union(i, j);
+    }
+  }
+  const groups = new Map();
+  for (let i = 0; i < n; i++) {
+    const r = find(i);
+    if (!groups.has(r)) groups.set(r, []);
+    groups.get(r).push(keys[i]);
+  }
+  return [...groups.values()];
+};
+
+// ─── Cutout generation (in keyfield-local coords) ─────────────────────
+
+const bboxOf = (cluster) => {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const k of cluster) {
+    minX = Math.min(minX, k.x);
+    maxX = Math.max(maxX, k.x + (k.w || 1));
+    minY = Math.min(minY, k.y);
+    maxY = Math.max(maxY, k.y + (k.h || 1));
+  }
+  return { minX, maxX, minY, maxY };
+};
+
+/**
+ * Compute cutouts in world coordinates.
+ * Each cutout = { cx, cz, w, d } — center + size in world XZ plane.
+ *
+ * @param {Array} keys
+ * @param {{width:number,height:number}} bounds   — keyfield bbox
+ * @param {{x:number,z:number}} mountOffset
+ * @param {Object} topFrame
+ */
+function buildCutouts(keys, bounds, mountOffset, topFrame) {
+  const cx0 = bounds.width / 2;
+  const cz0 = bounds.height / 2;
+  const offX = mountOffset.x || 0;
+  const offZ = mountOffset.z || 0;
+
+  if (topFrame.cutoutMode === "plate") {
+    // switchHoleSize is now interpreted as a SCALE on the key footprint
+    // (>1.0 = hole bigger than key, exposing visible plate around the
+    // cap from above; <1.0 = hole smaller than key, hidden by cap).
+    // Default 1.05 = hole 5% larger than key, leaving a clean rim of
+    // recessed plate visible around each cap.
+    const scale = topFrame.switchHoleSize ?? 1.05;
+    return keys.map((k) => ({
+      cx: (k.x + (k.w || 1) / 2) - cx0 + offX,
+      cz: (k.y + (k.h || 1) / 2) - cz0 + offZ,
+      w:  Math.max(0.05, (k.w || 1) * scale),
+      d:  Math.max(0.05, (k.h || 1) * scale),
+    }));
+  }
+
+  // tray mode — group then take bbox + borderWidth per cluster
+  const grouping = topFrame.grouping || "all";
+  const border = topFrame.borderWidth ?? 0.2;
+  let clusters;
+  if (grouping === "per-row")     clusters = clusterByRow(keys);
+  else if (grouping === "per-cluster") clusters = clusterByAdjacency(keys);
+  else                            clusters = [keys];
+
+  return clusters.map((cluster) => {
+    const b = bboxOf(cluster);
+    return {
+      cx: (b.minX + b.maxX) / 2 - cx0 + offX,
+      cz: (b.minY + b.maxY) / 2 - cz0 + offZ,
+      w:  (b.maxX - b.minX) + 2 * border,
+      d:  (b.maxY - b.minY) + 2 * border,
+    };
+  });
+}
+
+// ─── Mount-edge plane frame ────────────────────────────────────────────
+
+/**
+ * Compute the plane frame at the mount edge — basis vectors + origin —
+ * used to orient subtractor boxes onto the mount surface.
+ *
+ * Returns:
+ *   - tangent T: unit vector front → back (in YZ plane)
+ *   - outward normal Nout: perpendicular to T in YZ, pointing OUT of case
+ *   - front: world-space front edge anchor (X is irrelevant; Y/Z anchor)
+ *
+ * Axis mapping for a subtractor's local frame:
+ *   local.x → world.x        (cutout u axis)
+ *   local.y → world Nout     (positive = above mount surface)
+ *   local.z → world T        (positive = back direction)
+ */
+function mountEdgeFrame(profilePoints, mountEdge, depth, maxHeight) {
+  const maxPX = Math.max(...profilePoints.map((p) => p.x)) || 1;
+  const maxPY = Math.max(...profilePoints.map((p) => p.y)) || 1;
+  const scaleZ = depth / maxPX;
+  const scaleY = maxHeight / maxPY;
+
+  let a = profilePoints[mountEdge[0]];
+  let b = profilePoints[mountEdge[1]];
+  // front = lower profile.x = HIGHER world.z (depth/2 − x*scaleZ)
+  if (a.x > b.x) { const t = a; a = b; b = t; }
+  const front = { y: a.y * scaleY, z: depth / 2 - a.x * scaleZ };
+  const back  = { y: b.y * scaleY, z: depth / 2 - b.x * scaleZ };
+
+  const dy = back.y - front.y;
+  const dz = back.z - front.z;     // negative (going back = -z)
+  const L = Math.hypot(dy, dz);
+  if (L < 0.001) return null;
+  const T_y = dy / L, T_z = dz / L;
+  // Outward normal: rotate T by +90° in YZ (CCW when looking from +X):
+  //   (T_y, T_z) → (-T_z, T_y). For flat T=(0,-1) → Nout=(1,0) (up). ✓
+  const Nout_y = -T_z, Nout_z = T_y;
+
+  return { front, back, T_y, T_z, Nout_y, Nout_z, length: L };
+}
+
+// ─── Subtractor brushes ────────────────────────────────────────────────
+
+/**
+ * Build a subtractor Brush for one cutout. Box dimensions match the
+ * cutout's world XZ size; height = cutDepth + a small overlap ε so the
+ * top face protrudes slightly above the mount surface (avoids near-zero
+ * coplanar faces in CSG, which can leave thin caps).
+ */
+function buildCutoutGeo({ cutout, frame, cutDepth, mountOffsetY }) {
+  // Larger eps so the box's top face is CLEARLY above the mount edge
+  // surface — coplanar faces (eps=0.002) confuse the CSG/BVH and can
+  // cause the cut to silently no-op (box treated as fully inside case).
+  const eps = 0.05;
+  // Local box: (w × (cutDepth + eps) × d), centered on local origin.
+  // Local +y = outward normal direction. Translate so the box's TOP face
+  // (local +y of cutDepth/2 + eps/2 → 0) lands on the mount surface, and
+  // bottom face (local -y of cutDepth/2 + eps/2 → -cutDepth - eps) lands
+  // cutDepth deep into the case. The eps overlap above the mount surface
+  // prevents thin coplanar caps in the CSG output.
+  const geo = new THREE.BoxGeometry(cutout.w, cutDepth + eps, cutout.d);
+  geo.translate(0, -cutDepth / 2 + eps / 2, 0);
+
+  // Project cutout's world (cx, cz) onto plane: u = cx (local x = world x),
+  // v = arc length along edge from front.
+  const u = cutout.cx;
+  const v = (cutout.cz - frame.front.z) / frame.T_z;
+
+  // Plane-to-world matrix in one shot — translation column already
+  // includes the (u, 0, v) plane-space offset projected through the basis,
+  // so we don't need a follow-up translate.
+  const px = u;
+  const py = frame.front.y + mountOffsetY + v * frame.T_y;
+  const pz = frame.front.z                + v * frame.T_z;
+  const m = new THREE.Matrix4().set(
+    1, 0,             0,         px,
+    0, frame.Nout_y,  frame.T_y, py,
+    0, frame.Nout_z,  frame.T_z, pz,
+    0, 0,             0,         1,
+  );
+  geo.applyMatrix4(m);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+// ─── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Carve shallow grooves into the case body via CSG subtraction.
+ *
+ * @param {THREE.BufferGeometry} caseGeo   — output of extrudeCaseProfile
+ * @param {Object} caseProfile             — the eletypes-caseProfile/1 doc
+ * @param {Array} keys                     — resolved layout keys
+ * @param {{width:number,height:number}} bounds
+ * @param {number} caseW
+ * @param {number} caseD
+ * @param {number} extrudeWidth
+ * @param {{x?:number,y?:number,z?:number}} mountOffset
+ * @returns {THREE.BufferGeometry|null}    — carved case geometry, or null on failure
+ */
+export function carveCaseTop({
+  caseGeo, caseProfile, keys, bounds,
+  caseD, extrudeWidth, mountOffset = {},
+}) {
+  const tf = caseProfile?.topFrame;
+  if (!tf || !caseProfile?.points || !caseProfile?.mountEdge) return null;
+  if (keys.length === 0) return null;
+
+  const cutDepth = Math.max(0.01, tf.cutDepth ?? 0.1);
+
+  // Re-derive maxHeight the same way KeyboardModel.profileScale does, so
+  // the mount-edge frame matches the case body geometry exactly.
+  const maxPY = Math.max(...caseProfile.points.map((p) => p.y)) || 1;
+  const maxHeight = (maxPY / 60) * 2.0;
+
+  const frame = mountEdgeFrame(
+    caseProfile.points,
+    caseProfile.mountEdge,
+    caseD,
+    maxHeight,
+  );
+  if (!frame) return null;
+
+  const cutouts = buildCutouts(keys, bounds, mountOffset, tf);
+  if (cutouts.length === 0) return null;
+
+  const evaluator = new Evaluator();
+  // three-bvh-csg needs BOTH inputs to:
+  //  (1) expose the SAME attribute set (copies attribs through the op).
+  //      BoxGeometry has position+normal+uv; extrudeCaseProfile only emits
+  //      position — without padding uv we'd crash on .array undefined.
+  //  (2) be MANIFOLD (or close to it). extrudeCaseProfile emits each
+  //      face with its OWN unmerged vertex set, so adjacent faces have
+  //      duplicated coincident verts at edges — non-manifold for the
+  //      BVH, which then reads null normals on shared edges and crashes
+  //      with "Cannot read properties of null (reading 'dot')".
+  // mergeVertices welds duplicates by position+normal+uv equality, so we
+  // pad uv first, recompute normals, THEN merge.
+  // Strategy:
+  //   1. Clone case geometry, KEEP only `position` (drop normal/uv).
+  //   2. mergeVertices by position only — adjacent faces sharing an edge
+  //      now collapse to shared verts (they had the same position but
+  //      different per-face normals, which blocked the merge before).
+  //   3. Re-add a dummy uv (CSG copies attribs through the op, both
+  //      inputs need matching attribute set) and recompute smooth normals.
+  let padded = new THREE.BufferGeometry();
+  padded.setIndex(caseGeo.index);
+  padded.setAttribute("position", caseGeo.attributes.position.clone());
+  try {
+    padded = mergeVertices(padded, 1e-4);
+  } catch (e) {
+    // mergeVertices may throw on geometry without indices; carry on.
+  }
+  const posCount = padded.attributes.position.count;
+  padded.setAttribute("uv", new THREE.BufferAttribute(new Float32Array(posCount * 2), 2));
+  padded.computeVertexNormals();
+
+  try {
+    const subGeos = cutouts.map((c) => buildCutoutGeo({
+      cutout: c,
+      frame,
+      cutDepth,
+      mountOffsetY: mountOffset.y || 0,
+    }));
+    const subMerged = subGeos.length === 1
+      ? subGeos[0]
+      : mergeBufferGeometries(subGeos);
+    if (!subMerged) return null;
+
+    // Brushes need a material reference so three-bvh-csg's useGroups path
+    // tags result.geometry groups with materialIndex 0 (case) vs 1 (cutout
+    // interior). Actual rendering material comes from KeyboardModel via
+    // <mesh material={[caseMat, plateMat]} />.
+    const tagA = new THREE.MeshBasicMaterial();
+    const tagB = new THREE.MeshBasicMaterial();
+    const caseBrush = new Brush(padded, tagA);
+    caseBrush.updateMatrixWorld();
+    const subBrush = new Brush(subMerged, tagB);
+    subBrush.updateMatrixWorld();
+    evaluator.useGroups = true;
+    const result = evaluator.evaluate(caseBrush, subBrush, SUBTRACTION);
+    const out = result.geometry.clone();
+    if (!out.attributes.position || out.attributes.position.count === 0) {
+      console.warn("[carveTopCSG] empty result, falling back");
+      return null;
+    }
+    out.computeVertexNormals();
+    out.computeBoundingBox();
+    out.computeBoundingSphere();
+    return out;
+  } catch (err) {
+    console.warn("[carveTopCSG] CSG failed:", err);
+    return null;
+  }
+}

--- a/src/components/features/KeyboardLab/KeyboardModel.jsx
+++ b/src/components/features/KeyboardLab/KeyboardModel.jsx
@@ -19,6 +19,7 @@ import { computeBounds, buildKeyIndex, isAccentKey, extractKeys, parseLegendPosi
 import { DEFAULT_SHELL } from "./schema/shellProfile";
 import { createKeycapFromSpec } from "./KeycapGeometry";
 import { extrudeCaseProfile, computeMountSurface, extrudeEdgeStrip } from "./CaseEditor/extrudeProfile";
+import { carveCaseTop } from "./CaseEditor/carveTopCSG";
 import { resolveRenderStyle } from "./schema/types/renderStyle";
 import { Text } from "@react-three/drei";
 
@@ -161,10 +162,30 @@ const KeyboardModel = forwardRef(({
   }, [caseProfile]);
 
   // ─── Profile-based case geometry ───
+  // When caseProfile.topFrame is set, run CSG subtraction to bake the
+  // cutouts directly into the case body — single mesh, no plate-on-top.
+  // CSG is expensive (~50–200ms for 80 keys), but only runs when layout
+  // / profile / topFrame change (memoised).
   const profileCaseGeo = useMemo(() => {
     if (!profileScale) return null;
-    return extrudeCaseProfile(profileScale.points, caseW * extrudeWidth, caseD, profileScale.maxHeight);
-  }, [profileScale, caseW, caseD, extrudeWidth]);
+    const base = extrudeCaseProfile(
+      profileScale.points,
+      caseW * extrudeWidth,
+      caseD,
+      profileScale.maxHeight,
+    );
+    if (!caseProfile?.topFrame) return base;
+    const carved = carveCaseTop({
+      caseGeo: base,
+      caseProfile,
+      keys,
+      bounds,
+      caseD,
+      extrudeWidth,
+      mountOffset,
+    });
+    return carved || base;
+  }, [profileScale, caseW, caseD, extrudeWidth, caseProfile, keys, bounds, mountOffset]);
 
   // ─── Colored edge strip geometries ───
   const edgeStrips = useMemo(() => {
@@ -230,6 +251,10 @@ const KeyboardModel = forwardRef(({
         const t = (z + hd) / caseD;
         surfaceY = backTopY + t * (frontTopY - backTopY) + PLATE_Y;
       }
+      // Keys stay on the original mount surface — the carved cut goes
+      // DOWN into the case AROUND/BELOW them. Cap bottoms peek into the
+      // groove from above, exposing the cutout floor between keys (real
+      // plate look). Don't subtract cutDepth from surfaceY here.
 
       // Compute tilt angle for the key to sit flush on the surface
       let tiltAngleX = 0;
@@ -585,20 +610,21 @@ const KeyboardModel = forwardRef(({
 
   // Build a case/plate material — same mode switch as keycaps but keeps the
   // metallic PBR defaults for `pbr` mode since the case should look shiny.
-  const buildCaseMaterial = (mode, gm, { roughness, metalness, envMap }) => {
+  const buildCaseMaterial = (mode, gm, { roughness, metalness, envMap }, colorOverride) => {
+    const col = colorOverride || caseColor;
     if (mode === "cel-hard") {
-      return new THREE.MeshToonMaterial({ color: caseColor, gradientMap: gm, side: THREE.DoubleSide });
+      return new THREE.MeshToonMaterial({ color: col, gradientMap: gm, side: THREE.DoubleSide });
     }
     if (mode === "lofi-flat") {
-      return new THREE.MeshBasicMaterial({ color: caseColor, side: THREE.DoubleSide });
+      return new THREE.MeshBasicMaterial({ color: col, side: THREE.DoubleSide });
     }
     if (mode === "blueprint") {
-      return new THREE.MeshBasicMaterial({ color: caseColor, side: THREE.DoubleSide, wireframe: true });
+      return new THREE.MeshBasicMaterial({ color: col, side: THREE.DoubleSide, wireframe: true });
     }
     if (mode === "x-ray") {
       const opacity = resolvedCaseRS.xray.opacity;
       return new THREE.MeshBasicMaterial({
-        color: caseColor, side: THREE.DoubleSide,
+        color: col, side: THREE.DoubleSide,
         transparent: true, opacity,
         wireframe: !!resolvedCaseRS.xray.wireframe,
         depthWrite: false,
@@ -606,8 +632,8 @@ const KeyboardModel = forwardRef(({
     }
     if (mode === "neon") {
       return new THREE.MeshStandardMaterial({
-        color: caseColor,
-        emissive: caseColor,
+        color: col,
+        emissive: col,
         emissiveIntensity: resolvedCaseRS.neon.emissiveIntensity,
         roughness: resolvedCaseRS.neon.roughness,
         metalness: resolvedCaseRS.neon.metalness,
@@ -615,7 +641,7 @@ const KeyboardModel = forwardRef(({
       });
     }
     return new THREE.MeshStandardMaterial({
-      color: caseColor, roughness, metalness, envMapIntensity: envMap, side: THREE.DoubleSide,
+      color: col, roughness, metalness, envMapIntensity: envMap, side: THREE.DoubleSide,
     });
   };
 
@@ -634,6 +660,155 @@ const KeyboardModel = forwardRef(({
     () => buildCaseMaterial(casePrimary, caseGradientMap, { roughness: 0.35, metalness: 0.85, envMap: 0.6 }),
     [casePrimary, caseGradientMap, caseColor, caseProfile]
   );
+  // Cutout / mount-plate interior material — used as the second slot in
+  // the carved case mesh's material array. Falls back to caseColor when
+  // topFrame.color isn't set, so unconfigured cutouts blend into the case.
+  // Slightly higher roughness + lower envMap to read like a metal plate
+  // recessed inside a polished case. Backlight (if enabled) adds emissive
+  // properties so the cutout glows like a real switch LED.
+  const cutoutColor = caseProfile?.topFrame?.color;
+  const backlight = caseProfile?.topFrame?.backlight;
+  const cutoutMat = useMemo(() => {
+    const mat = buildCaseMaterial(
+      casePrimary,
+      caseGradientMap,
+      { roughness: 0.55, metalness: 0.6, envMap: 0.4 },
+      cutoutColor,
+    );
+    // Backlight = the visible light leaking out of the cap-to-plate gap
+    // around each key. The bright LED look comes from the bulb spheres +
+    // PointLights; cutout emissive is just a dim "lit plate" environment
+    // tint so the carved interior reads as colored, not glaring.
+    if (backlight && backlight.enabled !== false && mat.emissive) {
+      mat.emissive = new THREE.Color(backlight.color || "#ffffff");
+      const baseI = backlight.intensity ?? 0.8;
+      const bloom = backlight.bloom ?? 0;
+      mat.emissiveIntensity = baseI * (1 + bloom) * 0.35;
+    }
+    return mat;
+  }, [casePrimary, caseGradientMap, cutoutColor, caseColor, caseProfile, backlight]);
+
+  // ─── LED positions — at the CENTER OF EACH CAP'S BOTTOM EDGE, i.e.,
+  // in the cap-plate gap (mountSurfaceY + half PLATE_Y). From oblique
+  // viewing angles the bulb peeks out through the gap; the PointLight
+  // co-located here illuminates BOTH the cap's underside (above) AND
+  // the cutout floor (below) — same light source for both visuals.
+  const ledLightPositions = useMemo(() => {
+    if (!backlight || backlight.enabled === false) return [];
+    if (!keys.length) return [];
+    return keys.map((key) => {
+      const x = (key.x + (key.w || 1) / 2) - centerX + (mountOffset.x || 0);
+      const z = (key.y + (key.h || 1) / 2) - centerZ + (mountOffset.z || 0);
+      const zForSlope = (key.y + (key.h || 1) / 2) - centerZ;
+      const surfaceY = mountSurface ? mountSurface.getY(zForSlope) : 0;
+      // Cap base sits at surfaceY + PLATE_Y. Half-way between mount plate
+      // and cap base lands the LED in the visible cap-to-plate gap.
+      const y = surfaceY + PLATE_Y * 0.5;
+      return { x, y, z };
+    });
+  }, [keys, centerX, centerZ, mountOffset, mountSurface, backlight]);
+  const ledLightRefs = useRef([]);
+
+  // ─── Visible LED bulbs — small emissive spheres at each light position.
+  // Sphere radius bigger than the gap so the bottom protrudes into the
+  // cutout AND the top peeks past cap edges from oblique angles. The
+  // sphere center sits in the cap-plate gap; from above the cap covers
+  // it, but most camera angles see at least the rim.
+  const ledMeshRef = useRef(null);
+  const ledGeometry = useMemo(() => new THREE.SphereGeometry(0.06, 12, 8), []);
+  const ledBulbMat = useMemo(() => {
+    if (!backlight || backlight.enabled === false) return null;
+    return new THREE.MeshStandardMaterial({
+      color: 0x000000,
+      emissive: new THREE.Color(backlight.color || "#ffffff"),
+      emissiveIntensity: (backlight.intensity ?? 0.8) * (1 + (backlight.bloom ?? 0)) * 1.5,
+      vertexColors: true, // enable instanceColor for per-key wave
+      toneMapped: false,
+    });
+  }, [backlight]);
+  useEffect(() => {
+    if (!ledMeshRef.current || !ledLightPositions.length) return;
+    const m = new THREE.Matrix4();
+    for (let i = 0; i < ledLightPositions.length; i++) {
+      m.makeTranslation(ledLightPositions[i].x, ledLightPositions[i].y, ledLightPositions[i].z);
+      ledMeshRef.current.setMatrixAt(i, m);
+    }
+    ledMeshRef.current.instanceMatrix.needsUpdate = true;
+  }, [ledLightPositions]);
+
+  // Animated patterns drive emissive intensity / color each frame. For
+  // "wave" we'd need per-cutout material indices; until that lands, wave
+  // falls back to a slow global hue cycle so the visual still moves.
+  const _hslColor = useMemo(() => new THREE.Color(), []);
+  useFrame(({ clock }) => {
+    if (!backlight || backlight.enabled === false) return;
+    if (!cutoutMat?.emissive) return;
+    const pattern = backlight.pattern || "solid";
+    const speed = backlight.speed ?? 1.0;
+    const t = clock.getElapsedTime() * speed;
+    const baseI = backlight.intensity ?? 0.8;
+    const bloom = backlight.bloom ?? 0;
+    const peak = baseI * (1 + bloom);
+
+    // Helper to update emissive cutout material + every PointLight + every
+    // bulb mesh at once. With ONE light per key (~80 lights) each one's
+    // intensity is small (0.18×) so the cumulative scene illumination
+    // stays balanced. Bulb visible-emissive intensity is set via the
+    // material once (the per-instance color is what's animated).
+    const apply = (color, intensity) => {
+      cutoutMat.emissive.copy(color);
+      cutoutMat.emissiveIntensity = intensity * 0.35; // ambient tint, not glare
+      if (ledBulbMat?.emissive) {
+        ledBulbMat.emissive.copy(color);
+        ledBulbMat.emissiveIntensity = intensity * 1.5;
+      }
+      const perLightI = intensity * 0.5;
+      for (const ref of ledLightRefs.current) {
+        if (!ref) continue;
+        ref.color.copy(color);
+        ref.intensity = perLightI;
+      }
+    };
+
+    if (pattern === "solid") {
+      // Static — only run once on first frame to sync lights with the
+      // material's static config (which the useMemo above already set).
+      const col = new THREE.Color(backlight.color || "#ffffff");
+      apply(col, peak);
+      return;
+    }
+    if (pattern === "breathe") {
+      const i = peak * (0.3 + 0.7 * (0.5 + 0.5 * Math.sin(t * 1.5)));
+      const col = new THREE.Color(backlight.color || "#ffffff");
+      apply(col, i);
+    } else if (pattern === "rainbow") {
+      _hslColor.setHSL((t * 0.15) % 1.0, 1.0, 0.55);
+      apply(_hslColor, peak);
+    } else if (pattern === "wave") {
+      // Per-key colors — each PointLight + bulb gets a phase-shifted hue
+      // based on its world X position. Color travels left→right over time.
+      const perLightI = peak * 0.5;
+      const bulbMesh = ledMeshRef.current;
+      const _bulbColor = _hslColor; // reuse temp
+      for (let i = 0; i < ledLightRefs.current.length; i++) {
+        const ref = ledLightRefs.current[i];
+        const pos = ledLightPositions[i];
+        if (!ref || !pos) continue;
+        const phase = pos.x * 0.18 - t * 0.5;
+        const hue = ((phase % 1) + 1) % 1;
+        _bulbColor.setHSL(hue, 1.0, 0.55);
+        ref.color.copy(_bulbColor);
+        ref.intensity = perLightI;
+        if (bulbMesh) bulbMesh.setColorAt(i, _bulbColor);
+      }
+      if (bulbMesh?.instanceColor) bulbMesh.instanceColor.needsUpdate = true;
+      // Cutout emissive uses an averaged hue so the gap glow doesn't strobe.
+      _hslColor.setHSL((t * 0.1) % 1.0, 0.85, 0.55);
+      cutoutMat.emissive.copy(_hslColor);
+      cutoutMat.emissiveIntensity = peak * 0.35;
+    }
+    invalidate();
+  });
 
   // Case outline — for cel-hard we want a constant-thickness silhouette that
   // doesn't blow up with the case's scale. Classic Blinn back-face trick:
@@ -806,10 +981,19 @@ const KeyboardModel = forwardRef(({
           body's depth test punches out the interior. */}
       {profileCaseGeo ? (
         <React.Fragment key={`case-profile-${caseProfileKey}`}>
-          <mesh position={[0, 0, caseCenterZ]}>
-            <primitive object={profileCaseGeo} attach="geometry" />
-            <primitive object={caseMat} attach="material" />
-          </mesh>
+          {/* When CSG-carved, the geometry has groups: 0 = original case
+              faces, 1 = cutout interior (walls + floor). Pass [caseMat,
+              cutoutMat] so each group renders with its own color. */}
+          {caseProfile?.topFrame ? (
+            <mesh position={[0, 0, caseCenterZ]} material={[caseMat, cutoutMat]}>
+              <primitive object={profileCaseGeo} attach="geometry" />
+            </mesh>
+          ) : (
+            <mesh position={[0, 0, caseCenterZ]}>
+              <primitive object={profileCaseGeo} attach="geometry" />
+              <primitive object={caseMat} attach="material" />
+            </mesh>
+          )}
           {caseOutlineActive && caseOutlineMaterial && (
             <mesh position={[0, 0, caseCenterZ]} renderOrder={-1}>
               <primitive object={profileCaseGeo} attach="geometry" />
@@ -844,6 +1028,33 @@ const KeyboardModel = forwardRef(({
           )}
         </React.Fragment>
       )}
+
+      {/* LED bulbs — one tiny emissive sphere per key, sitting in the
+          cap-plate gap. Acts as a visible "lit LED dot" peeking out from
+          oblique angles. */}
+      {backlight?.enabled !== false && ledBulbMat && ledLightPositions.length > 0 && (
+        <instancedMesh
+          ref={ledMeshRef}
+          args={[ledGeometry, ledBulbMat, ledLightPositions.length]}
+          frustumCulled={false}
+        />
+      )}
+
+      {/* Backlight scene lights — one PointLight per key, co-located with
+          its bulb. Lights both the cap underside (above) and the cutout
+          floor (below). distance ≈ 0.6u keeps each light localized so
+          the per-key gradient is visible on the plate. */}
+      {ledLightPositions.map((p, i) => (
+        <pointLight
+          key={`led-${i}`}
+          ref={(el) => { ledLightRefs.current[i] = el; }}
+          position={[p.x, p.y, p.z]}
+          color={backlight?.color || "#ffffff"}
+          intensity={(backlight?.intensity ?? 0.8) * (1 + (backlight?.bloom ?? 0)) * 0.5}
+          distance={1.2}
+          decay={1.5}
+        />
+      ))}
 
       {/* Colored edge accent strips */}
       {edgeStrips.map((strip, i) => (

--- a/src/components/features/KeyboardLab/presets/cyberboard75.js
+++ b/src/components/features/KeyboardLab/presets/cyberboard75.js
@@ -13,11 +13,12 @@
 import { createPreset } from "../schema/boardLayout";
 
 const R0 = 0, R1 = 1.25, R2 = 2.25, R3 = 3.25, R4 = 4.25, R5 = 5.25;
-// Nav column shifted left 0.5 so Home/End/PgUp/PgDn line up with the right
-// arrow (which itself moved left 0.25 on top of the AltRight removal). Delete
-// stays one column to its left.
-const RC_LEFT = 14;    // Delete position
-const RC = 15;         // Right column (Home, End, PgUp, PgDn) — aligned with ArrowRight
+// Every inter-group gap in the F-row is the same: 0.24u (= 3× the cap-to-
+// cap gap of 0.08). Groups: Esc | F1-F4 | F5-F8 | F9-F12 | Del-Home.
+// Right column / arrow cluster land at 14.96 (only 0.04u left of the
+// original 15, so wide keys keep close-to-standard widths).
+const RC_LEFT = 13.96;   // Delete position
+const RC = 14.96;        // Right column (Home, End, PgUp, PgDn) — aligned with ArrowRight
 
 export default createPreset({
   name: "Cyberboard R2 75%",
@@ -37,18 +38,18 @@ export default createPreset({
   keys: [
     // ══ Row 0: Function row — Delete shifted left, Home at corner ══
     { id: "Escape",  keyName: "Escape",  label: "Esc",  x: 0,        y: R0, w: 1,    kind: "accent", cluster: "fn-row" },
-    { id: "F1",      keyName: "F1",      label: "F1",   x: 1.5,      y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F2",      keyName: "F2",      label: "F2",   x: 2.5,      y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F3",      keyName: "F3",      label: "F3",   x: 3.5,      y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F4",      keyName: "F4",      label: "F4",   x: 4.5,      y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F5",      keyName: "F5",      label: "F5",   x: 5.75,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F6",      keyName: "F6",      label: "F6",   x: 6.75,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F7",      keyName: "F7",      label: "F7",   x: 7.75,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F8",      keyName: "F8",      label: "F8",   x: 8.75,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F9",      keyName: "F9",      label: "F9",   x: 10,       y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F10",     keyName: "F10",     label: "F10",  x: 11,       y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F11",     keyName: "F11",     label: "F11",  x: 12,       y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
-    { id: "F12",     keyName: "F12",     label: "F12",  x: 13,       y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F1",      keyName: "F1",      label: "F1",   x: 1.24,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F2",      keyName: "F2",      label: "F2",   x: 2.24,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F3",      keyName: "F3",      label: "F3",   x: 3.24,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F4",      keyName: "F4",      label: "F4",   x: 4.24,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F5",      keyName: "F5",      label: "F5",   x: 5.48,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F6",      keyName: "F6",      label: "F6",   x: 6.48,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F7",      keyName: "F7",      label: "F7",   x: 7.48,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F8",      keyName: "F8",      label: "F8",   x: 8.48,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F9",      keyName: "F9",      label: "F9",   x: 9.72,     y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F10",     keyName: "F10",     label: "F10",  x: 10.72,    y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F11",     keyName: "F11",     label: "F11",  x: 11.72,    y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
+    { id: "F12",     keyName: "F12",     label: "F12",  x: 12.72,    y: R0, w: 1,    kind: "fn",     cluster: "fn-row" },
     { id: "Delete",  keyName: "Delete",  label: "Del",  x: RC_LEFT,  y: R0, w: 1,    kind: "nav",    cluster: "nav-col" },
     { id: "Home",    keyName: "Home",    label: "Home", x: RC,       y: R0, w: 1,    kind: "nav",    cluster: "nav-col" },
 
@@ -66,7 +67,7 @@ export default createPreset({
     { id: "Digit0",     keyName: "Digit0",     label: "0",    x: 10,  y: R1, w: 1,   kind: "alpha", cluster: "number-row" },
     { id: "Minus",      keyName: "Minus",      label: "-",    x: 11,  y: R1, w: 1,   kind: "alpha", cluster: "number-row" },
     { id: "Equal",      keyName: "Equal",      label: "=",    x: 12,  y: R1, w: 1,   kind: "alpha", cluster: "number-row" },
-    { id: "Backspace",  keyName: "Backspace",  label: "Bksp", x: 13,  y: R1, w: 2,   kind: "accent", cluster: "number-row" },
+    { id: "Backspace",  keyName: "Backspace",  label: "Bksp", x: 13,     y: R1, w: 1.96, kind: "accent", cluster: "number-row" },
     { id: "End",        keyName: "End",        label: "End",  x: RC,  y: R1, w: 1,   kind: "nav",   cluster: "nav-col" },
 
     // ══ Row 2: QWERTY — PgUp in right column ══
@@ -83,7 +84,7 @@ export default createPreset({
     { id: "KeyP",          keyName: "KeyP",         label: "P",    x: 10.5, y: R2, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "BracketLeft",   keyName: "BracketLeft",  label: "[",    x: 11.5, y: R2, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "BracketRight",  keyName: "BracketRight", label: "]",    x: 12.5, y: R2, w: 1,    kind: "alpha",  cluster: "alpha" },
-    { id: "Backslash",     keyName: "Backslash",    label: "\\",   x: 13.5, y: R2, w: 1.5,  kind: "alpha",  cluster: "alpha" },
+    { id: "Backslash",     keyName: "Backslash",    label: "\\",   x: 13.5, y: R2, w: 1.46, kind: "alpha",  cluster: "alpha" },
     { id: "PageUp",        keyName: "PageUp",       label: "PgUp", x: RC,   y: R2, w: 1,    kind: "nav",    cluster: "nav-col" },
 
     // ══ Row 3: Home row — PgDn in right column ══
@@ -99,7 +100,7 @@ export default createPreset({
     { id: "KeyL",       keyName: "KeyL",       label: "L",     x: 9.75,  y: R3, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "Semicolon",  keyName: "Semicolon",  label: ";",     x: 10.75, y: R3, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "Quote",      keyName: "Quote",      label: "'",     x: 11.75, y: R3, w: 1,    kind: "alpha",  cluster: "alpha" },
-    { id: "Enter",      keyName: "Enter",      label: "Enter", x: 12.75, y: R3, w: 2.25, kind: "accent", cluster: "alpha" },
+    { id: "Enter",      keyName: "Enter",      label: "Enter", x: 12.75, y: R3, w: 2.21, kind: "accent", cluster: "alpha" },
     { id: "PageDown",   keyName: "PageDown",   label: "PgDn",  x: RC,    y: R3, w: 1,    kind: "nav",    cluster: "nav-col" },
 
     // ══ Row 4: Shift row — ↑ flush with right Shift ══
@@ -114,8 +115,8 @@ export default createPreset({
     { id: "Comma",      keyName: "Comma",      label: ",",     x: 9.25,  y: R4, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "Period",     keyName: "Period",      label: ".",     x: 10.25, y: R4, w: 1,    kind: "alpha",  cluster: "alpha" },
     { id: "Slash",      keyName: "Slash",       label: "/",     x: 11.25, y: R4, w: 1,    kind: "alpha",  cluster: "alpha" },
-    { id: "ShiftRight", keyName: "ShiftRight",  label: "Shift", x: 12.25, y: R4, w: 1.75, kind: "accent", cluster: "alpha" },
-    { id: "ArrowUp",    keyName: "ArrowUp",     label: "↑",     x: 14,    y: R4, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
+    { id: "ShiftRight", keyName: "ShiftRight",  label: "Shift", x: 12.25, y: R4, w: 1.71, kind: "accent", cluster: "alpha" },
+    { id: "ArrowUp",    keyName: "ArrowUp",     label: "↑",     x: 13.96, y: R4, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
     // No nav key at RC on this row — gap between ↑ and right edge
 
     // ══ Row 5: Bottom row — no AltRight; Fn + Ctrl flush with spacebar ══
@@ -130,8 +131,8 @@ export default createPreset({
     { id: "Fn",           keyName: "Fn",           label: "Fn",   x: 10,    y: R5, w: 1.25, kind: "mod",    cluster: "bottom-row" },
     { id: "ControlRight", keyName: "ControlRight", label: "Ctrl", x: 11.25, y: R5, w: 1.25, kind: "mod",    cluster: "bottom-row" },
     // Arrow cluster shifted left by 0.25 to match ArrowUp under it.
-    { id: "ArrowLeft",    keyName: "ArrowLeft",    label: "←",    x: 13,    y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
-    { id: "ArrowDown",    keyName: "ArrowDown",    label: "↓",    x: 14,    y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
-    { id: "ArrowRight",   keyName: "ArrowRight",   label: "→",    x: 15,    y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
+    { id: "ArrowLeft",    keyName: "ArrowLeft",    label: "←",    x: 12.96, y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
+    { id: "ArrowDown",    keyName: "ArrowDown",    label: "↓",    x: 13.96, y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
+    { id: "ArrowRight",   keyName: "ArrowRight",   label: "→",    x: 14.96, y: R5, w: 1,    kind: "arrow",  cluster: "arrow-cluster" },
   ],
 });

--- a/src/components/features/KeyboardLab/presets/profiles.js
+++ b/src/components/features/KeyboardLab/presets/profiles.js
@@ -22,6 +22,26 @@ export const CYBERBOARD_WEDGE_PROFILE = {
       { from: 4, to: 0, color: "#36223a" },
       { from: 3, to: 4, color: "#483232" },
     ],
+    // Plate-style — one cutout per key. switchHoleSize is a scale on the
+    // key footprint: 1.05 = hole 5% larger than key, so a thin rim of
+    // recessed plate surface shows around each cap from above. color picks
+    // the visible plate tone — dark gunmetal contrasts the lavender case.
+    // backlight adds an emissive LED glow to the plate; the cap-to-plate
+    // gap reads as light bleeding up around each key.
+    topFrame: {
+      cutoutMode: "plate",
+      switchHoleSize: 1.05,
+      cutDepth: 0.1,
+      color: "#1a1a20",
+      backlight: {
+        enabled: true,
+        color: "#ff44aa",
+        intensity: 1.0,
+        pattern: "wave",
+        speed: 0.8,
+        bloom: 0.5,
+      },
+    },
   },
   mount: {
     offset: { x: 0.1, y: 0, z: 0.7 },

--- a/src/components/features/KeyboardLab/schema/types/profile.js
+++ b/src/components/features/KeyboardLab/schema/types/profile.js
@@ -17,12 +17,56 @@
  * @property {Array<{x:number, y:number, d?:number}>} points — Cross-section polygon
  * @property {number[]} mountEdge — [fromIndex, toIndex] edge where keys mount
  * @property {ColoredEdge[]} [coloredEdges] — Accent-colored edges on the case
+ * @property {TopFrame} [topFrame] — Optional shallow cutouts in the case top
  *
  * @typedef {Object} ColoredEdge
  * @property {number} from       — Start point index
  * @property {number} to         — End point index
  * @property {string} color      — Hex color for this edge strip
  * @property {number} [emissive] — Emissive intensity 0-1 (default 0.5, LED-strip glow)
+ *
+ * @typedef {Object} TopFrame
+ *   Shallow grooves cut into the case top (real CSG subtraction — produces
+ *   one mesh with cavities baked in, NOT a separate plate on top).
+ * @property {"plate"|"tray"} cutoutMode
+ *   - "plate": one switch-sized hole per key (real keyboard plate look).
+ *              Hole size scales with the key — hole.w = key.w - (1 - switchHoleSize).
+ *   - "tray":  one rectangular cutout per group (cluster bbox + borderWidth).
+ * @property {number} [switchHoleSize=1.05]   — plate mode — SCALE on key
+ *   footprint. >1 = hole bigger than key (visible plate rim around cap).
+ *   <1 = hole smaller than key (hidden by cap, real metal plate look).
+ * @property {"all"|"per-row"|"per-cluster"} [grouping="all"]
+ *   tray mode only — how to cluster keys into cutout groups.
+ *   Ignored in plate mode (cluster spacing emerges naturally from key gaps).
+ * @property {number} [borderWidth=0.2]       — tray mode — outer offset around cluster bbox.
+ * @property {number} [cutDepth=0.1]          — depth of the groove (key units).
+ * @property {number} [cornerRadius=0]        — tray mode only — inner corner radius.
+ *   Plate mode is always sharp-cornered (matches a real metal mount plate).
+ * @property {string} [color]                 — color of the cutout interior
+ *   (plate surface visible through the holes). Falls back to caseColor when
+ *   unset. CSG result tags faces from the case body as group 0 and faces
+ *   from the cutout volumes as group 1, so a 2-material array {caseMat,
+ *   plateMat} renders the carved mesh with the right color in each region.
+ * @property {Backlight} [backlight]
+ *
+ * @typedef {Object} Backlight
+ *   Per-cutout LED glow — applies an emissive material to the cutout
+ *   interior so light reads as bleeding up around each cap (the cap-to-
+ *   plate gap). Only meaningful when topFrame is set.
+ * @property {boolean} [enabled=true]   — Master switch.
+ * @property {string} [color="#ffffff"] — Base emissive color (solid mode).
+ * @property {number} [intensity=0.8]   — Emissive intensity 0..3 (>1 reads as
+ *   real LED hot-spot; the case gets a subtle bounce light from the cutouts).
+ * @property {"solid"|"breathe"|"rainbow"|"wave"} [pattern="solid"]
+ *   - "solid"   — constant color glow.
+ *   - "breathe" — sinusoidal pulse on emissiveIntensity.
+ *   - "rainbow" — emissive color cycles through full hue spectrum.
+ *   - "wave"    — color shifts in a moving wave along the layout (uses
+ *                 cutout center positions to phase-shift each face).
+ * @property {number} [speed=1.0]       — Animation speed multiplier.
+ * @property {number} [bloom=0]         — 0..2, multiplier applied to base
+ *   intensity for a "hot LED" feel. Uses high emissiveIntensity rather
+ *   than postprocess bloom (so it works without an EffectComposer).
  *
  * @typedef {Object} MountSettings
  * @property {{x:number, y:number, z:number}} [offset] — Keycap group position offset


### PR DESCRIPTION
- caseProfile.topFrame schema: plate (per-key holes) | tray (grouped cluster bbox cutouts with all/per-row/per-cluster grouping)
- CSG subtraction via three-bvh-csg bakes cutouts into the case body — one mesh, no plate-on-top, geometry handles wedge slope
- Carved geometry uses BufferGeometry groups so [caseMat, cutoutMat] lets the cutout interior take its own color/material
- topFrame.backlight: per-key LED system — visible bulb sphere + co-located PointLight + dim cutout emissive ambient. Patterns: solid, breathe, rainbow, wave (per-key phase shift via instanceColor)
- Cyberboard R2 layout: F-row groups (Esc | F1-F4 | F5-F8 | F9-F12 | Del-Home) all separated by 3× cap-gap (0.24u). Wide keys + arrow cluster shift to keep right-column alignment
- CaseProfileEditor preserves topFrame through onChange round-trips so async-loaded profiles don't strip the field on first edit