### PR TITLE
fix(news-tab): handle profile-tab: pseudo-URL in renderNewsHighlighted

### DIFF
--- a/src/components/common/Logo.jsx
+++ b/src/components/common/Logo.jsx
@@ -128,11 +128,16 @@ const renderHighlighted = (text, highlights, theme) => {
     // named tab instead of navigating out. Useful for in-app CTAs
     // (e.g., the creator-recruit banner) where the destination is a
     // pitch page that lives inside this app, not an external link.
+    // Rendered as <a href="#"> with a click handler rather than
+    // <button> so the element flows inline inside the banner's flex
+    // container exactly like the external-link case — <button>'s
+    // default inline-block layout broke the banner across 3 lines.
     if (typeof matchedHighlight.link === "string" && matchedHighlight.link.startsWith("profile-tab:")) {
       const tab = matchedHighlight.link.slice("profile-tab:".length);
       parts.push(
-        <button
+        <a
           key={key++}
+          href="#"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -140,19 +145,10 @@ const renderHighlighted = (text, highlights, theme) => {
               new CustomEvent("eletypes-open-profile", { detail: { tab } })
             );
           }}
-          style={{
-            background: "transparent",
-            border: "none",
-            padding: 0,
-            font: "inherit",
-            color: theme.stats,
-            textDecoration: "underline",
-            fontWeight: 600,
-            cursor: "pointer",
-          }}
+          style={{ color: theme.stats, textDecoration: "underline", fontWeight: 600, cursor: "pointer" }}
         >
           {label}
-        </button>
+        </a>
       );
     } else if (matchedHighlight.link) {
       parts.push(

--- a/src/components/common/ProfileModal.jsx
+++ b/src/components/common/ProfileModal.jsx
@@ -69,7 +69,31 @@ const renderNewsHighlighted = (text, highlights, theme) => {
     }
 
     const label = matchedHighlight.placeholder;
-    if (matchedHighlight.link) {
+    // Mirror the `profile-tab:<id>` pseudo-URL handling from Logo.jsx
+    // — without this, clicking a highlight in the News tab whose link
+    // is "profile-tab:creators" sends the browser to that literal URL
+    // and goes nowhere. We intercept it and dispatch the same
+    // eletypes-open-profile event the banner uses, which the Logo
+    // listener turns into a tab switch on the already-open modal.
+    if (typeof matchedHighlight.link === "string" && matchedHighlight.link.startsWith("profile-tab:")) {
+      const tab = matchedHighlight.link.slice("profile-tab:".length);
+      parts.push(
+        <a
+          key={key++}
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            window.dispatchEvent(
+              new CustomEvent("eletypes-open-profile", { detail: { tab } })
+            );
+          }}
+          style={{ color: theme.stats, textDecoration: "underline", fontWeight: 600, cursor: "pointer" }}
+        >
+          {label}
+        </a>
+      );
+    } else if (matchedHighlight.link) {
       parts.push(
         <a
           key={key++}


### PR DESCRIPTION
The creator-recruit banner's `{提交友链申请}` / `{submit your link}` highlight uses link `profile-tab:creators` so clicks switch tabs inside the already-open Profile modal instead of navigating away. Logo.jsx's renderHighlighted understood this, but the Profile modal's renderNewsHighlighted (which renders the same banner items in their full-text form on the News tab) did not — it emitted

    <a href="profile-tab:creators" target="_blank">

so clicking the link in the News tab popped a new tab to that literal URL and went nowhere.

Mirror the same pseudo-URL handling: render <a href="#"> with onClick that dispatches `eletypes-open-profile` with the requested tab. Logo's existing listener turns that into a tab switch on the already-mounted modal.