### PR TITLE
feat(i18n): exclude typing content from browser auto-translation

### DIFF
--- a/src/components/common/ChineseModeWords.jsx
+++ b/src/components/common/ChineseModeWords.jsx
@@ -48,7 +48,7 @@ const ChineseModeWords = ({
           theme={theme}
         />
       )}
-      <div className="words">
+      <div className="words notranslate" translate="no">
         {currentWords.map((word, i) => {
           const opacityValue = isUltraZenMode ? getWordOpacity(i) : 1;
 

--- a/src/components/common/EnglishModeWords.jsx
+++ b/src/components/common/EnglishModeWords.jsx
@@ -44,7 +44,7 @@ const EnglishModeWords = ({
           theme={theme}
         />
       )}
-      <div className="words">
+      <div className="words notranslate" translate="no">
         {currentWords.map((word, i) => {
           const globalIndex = startIndex + i;
 

--- a/src/components/features/SentenceBox/SentenceBox.jsx
+++ b/src/components/features/SentenceBox/SentenceBox.jsx
@@ -277,7 +277,7 @@ const SentenceBox = ({
     <div onClick={handleInputFocus}>
       <div className="type-box-sentence">
         <Stack spacing={2}>
-          <div className="sentence-display-field">
+          <div className="sentence-display-field notranslate" translate="no">
             {currSentence.split("").map((char, idx) => (
               <span key={"word" + idx} className={getCharClassName(idx, char)}>
                 {char}
@@ -297,7 +297,7 @@ const SentenceBox = ({
             onChange={handleChange}
           />
           {status !== "finished" && (
-            <span className="next-sentence-display">
+            <span className="next-sentence-display notranslate" translate="no">
               {"->"} {sentences[currSentenceIndex + 1] ?? "Press ↵ to finish."}
             </span>
           )}

--- a/src/components/features/WordsCard/WordsCard.jsx
+++ b/src/components/features/WordsCard/WordsCard.jsx
@@ -489,7 +489,7 @@ const WordsCard = ({ soundType, soundMode }) => {
           onKeyDown={(e) => handleKeyDown(e)}
           // disabled={mode !== "vocab"}
         ></input>
-        <div className="wordcard-meaning-display-field">{currMeaning}</div>
+        <div className="wordcard-meaning-display-field notranslate" translate="no">{currMeaning}</div>
         {
           mode === "vocab" &&
           <>
@@ -529,7 +529,7 @@ const WordsCard = ({ soundType, soundMode }) => {
             </Tooltip>
           </>
         }
-        <div className="wordcard-word-display-field">
+        <div className="wordcard-word-display-field notranslate" translate="no">
           {currWord.split("").map((char, idx) => (
             <span key={"word" + idx} className={getCharClassName(idx, char)}>
               {getCharDisplay(idx, char)}


### PR DESCRIPTION
Browser translators (Chrome/Edge/Safari) rewrite DOM text nodes in place, which corrupts the per-character spans the typing test matches against, breaking matching, WPM, and error stats.

Mark game-content subtrees with translate="no" + notranslate so they are skipped by translators, while leaving the rest of the UI (toolbar, menus, stats) translatable:
- EnglishModeWords / ChineseModeWords: the .words container
- SentenceBox: sentence display + next-sentence preview
- WordsCard: vocab word + meaning fields