### PR TITLE
修复中文模式续词逻辑&光标显示问题&续词渲染问题

### DIFF
--- a/src/components/common/ChineseModeWords.jsx
+++ b/src/components/common/ChineseModeWords.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useRef, useMemo } from "react";
+import React, { memo, useCallback, useRef } from "react";
 import SmoothCaret from "../features/TypeBox/SmoothCaret";
 
 const ChineseModeWords = ({
@@ -10,6 +10,7 @@ const ChineseModeWords = ({
   isUltraZenMode,
   status,
   wordSpanRefs,
+  startIndex,
   getChineseWordKeyClassName,
   getChineseWordClassName,
   getCharClassName,
@@ -29,14 +30,11 @@ const ChineseModeWords = ({
   const hanziStyle =
     chineseDisplayMode === "pinyin" ? { visibility: "hidden" } : undefined;
 
-  // Separate refs for character spans (used by SmoothCaret)
-  const charWordRefs = useMemo(
-    () => currentWords.map(() => React.createRef()),
-    [currentWords]
-  );
-
+  // The full-length wordSpanRefs (attached to each pinyin span below) serves
+  // both the TypeBox scroll anchoring and the SmoothCaret measurement.
   const getWordOpacity = useCallback(
-    (index) => Math.max(1 - Math.abs(index - currWordIndex) * 0.1, 0.1),
+    (globalIndex) =>
+      Math.max(1 - Math.abs(globalIndex - currWordIndex) * 0.1, 0.1),
     [currWordIndex]
   );
 
@@ -52,46 +50,47 @@ const ChineseModeWords = ({
       {pacingStyle === "caret" && (
         <SmoothCaret
           containerRef={containerRef}
-          wordSpanRefs={charWordRefs}
+          wordSpanRefs={wordSpanRefs}
           currWordIndex={currWordIndex}
           currCharIndex={currCharIndex}
+          startIndex={startIndex}
           status={status}
           theme={theme}
         />
       )}
       <div className="words notranslate" translate="no">
         {currentWords.map((word, i) => {
-          const opacityValue = isUltraZenMode ? getWordOpacity(i) : 1;
+          const globalIndex = startIndex + i;
+          const opacityValue = isUltraZenMode ? getWordOpacity(globalIndex) : 1;
 
           return (
             <div
-              key={i}
+              key={globalIndex}
               style={{
                 opacity: opacityValue,
                 transition: "500ms",
               }}
             >
               <span
-                className={getChineseWordKeyClassName(i)}
-                ref={wordSpanRefs[i]}
+                className={getChineseWordKeyClassName(globalIndex)}
                 style={hanziStyle}
               >
-                {wordsKey[i]}
+                {wordsKey[globalIndex]}
               </span>
               <span
-                className={getChineseWordClassName(i)}
-                ref={charWordRefs[i]}
+                className={getChineseWordClassName(globalIndex)}
+                ref={wordSpanRefs[globalIndex]}
                 style={pinyinStyle}
               >
                 {word.split("").map((char, idx) => (
                   <span
-                    key={`word${i}_${idx}`}
-                    className={getCharClassName(i, idx, char, word)}
+                    key={`word${globalIndex}_${idx}`}
+                    className={getCharClassName(globalIndex, idx, char, word)}
                   >
                     {char}
                   </span>
                 ))}
-                {getExtraCharsDisplay(word, i)}
+                {getExtraCharsDisplay(word, globalIndex)}
               </span>
             </div>
           );

--- a/src/components/features/TypeBox/TypeBox.jsx
+++ b/src/components/features/TypeBox/TypeBox.jsx
@@ -1416,6 +1416,7 @@ const TypeBox = ({
             isUltraZenMode={isUltraZenMode}
             status={status}
             wordSpanRefs={wordSpanRefs}
+            startIndex={startIndex}
             getChineseWordKeyClassName={getChineseWordKeyClassName}
             getChineseWordClassName={getChineseWordClassName}
             getCharClassName={getCharClassName}

--- a/src/constants/WordsMostCommon.js
+++ b/src/constants/WordsMostCommon.js
@@ -3,9 +3,11 @@ import EnglishMostFrequentWords from '../assets/Vocab/EnglishMostFrequentWords.j
 import Chinese1500IdiomsPinyin from '../assets/Vocab/Chinese1500IdiomsPinyin.json';
 
 
-const COMMON_WORDS = EnglishMostFrequentWords;
-const COMMON_CHINESE_WORDS = Chinese5000WordsPinyin;
-const COMMON_CHINESE_IDIOMS_WORDS = Chinese1500IdiomsPinyin;
+// The JSON vocab files are keyed objects ({"0": {...}, ...}) rather than
+// arrays — normalize to plain arrays so consumers can rely on .length.
+const COMMON_WORDS = Object.values(EnglishMostFrequentWords);
+const COMMON_CHINESE_WORDS = Object.values(Chinese5000WordsPinyin);
+const COMMON_CHINESE_IDIOMS_WORDS = Object.values(Chinese1500IdiomsPinyin);
 
 
 export {

--- a/src/scripts/wordsGenerator.js
+++ b/src/scripts/wordsGenerator.js
@@ -1,4 +1,4 @@
-import randomWords, { wordList as hardWordList } from "random-words";
+import { wordList as hardWordList } from "random-words";
 import {
   COMMON_WORDS,
   COMMON_CHINESE_WORDS,
@@ -6,6 +6,7 @@ import {
 } from "../constants/WordsMostCommon";
 import {
   DEFAULT_DIFFICULTY,
+  HARD_DIFFICULTY,
   ENGLISH_MODE,
   CHINESE_MODE,
   DEFAULT_WORDS_COUNT,
@@ -20,6 +21,65 @@ import {
   DICTIONARY_SOURCE_CATALOG,
 } from "../constants/DictionaryConstants";
 
+// hard — select from random-words wordList with seeded RNG for determinism
+const HARD_ENGLISH_WORDS = hardWordList.filter((w) => w.length <= 7);
+
+// Draw indices against bank.length - 1 so the bound always stays in sync
+// with the selected word bank. Previously each mode had its own hardcoded
+// range (e.g. Chinese idioms drew 0..5000 against a 1500-entry list), which
+// silently shrank generated batches when the range exceeded the bank size.
+// Swapping a word list now only requires updating this map — nothing else.
+const WORD_BANK_BY_MODE = {
+  [ENGLISH_MODE]: {
+    [DEFAULT_DIFFICULTY]: COMMON_WORDS,
+    [HARD_DIFFICULTY]: HARD_ENGLISH_WORDS,
+  },
+  [CHINESE_MODE]: {
+    [DEFAULT_DIFFICULTY]: COMMON_CHINESE_WORDS,
+    [HARD_DIFFICULTY]: COMMON_CHINESE_IDIOMS_WORDS,
+  },
+};
+
+const generateWordsFromBank = (bank, count, numberAddOn, symbolAddOn, rng) => {
+  const wordList = [];
+  const bankLength = bank.length;
+  for (let i = 0; i < count; i++) {
+    const rand = randomIntFromRange(0, bankLength - 1, rng);
+    const entry = bank[rand];
+    // guard against sparse banks — the draw range stays within bank.length,
+    // so this only fires when a bank entry itself is missing/empty
+    if (!entry) {
+      continue;
+    }
+    // banks store either { key, val } objects (vocab JSON) or plain strings
+    // (random-words wordList) — normalize both to { key, val }
+    let wordCandidateKey =
+      typeof entry === "string" ? entry : entry.key;
+    let wordCandidateVal =
+      typeof entry === "string" ? entry : entry.val;
+    if (!wordCandidateKey || !wordCandidateVal) {
+      continue;
+    }
+    if (numberAddOn) {
+      const generatedNumber = generateRandomNumChras(1, 2, rng);
+      wordCandidateKey = wordCandidateKey + generatedNumber;
+      wordCandidateVal = wordCandidateVal + generatedNumber;
+    }
+    if (symbolAddOn) {
+      const generatedSymbol = generateRandomSymbolChras(1, 1, rng);
+      wordCandidateKey = wordCandidateKey + generatedSymbol;
+      wordCandidateVal = wordCandidateVal + generatedSymbol;
+    }
+
+    wordList.push({
+      key: wordCandidateKey,
+      val: wordCandidateVal,
+    });
+  }
+
+  return wordList;
+};
+
 const wordsGenerator = (
   wordsCount,
   difficulty,
@@ -29,37 +89,13 @@ const wordsGenerator = (
   rng
 ) => {
   if (languageMode === ENGLISH_MODE) {
-    if (difficulty === DEFAULT_DIFFICULTY) {
-      const EnglishWordList = [];
-      for (let i = 0; i < DEFAULT_WORDS_COUNT; i++) {
-        const rand = randomIntFromRange(0, 550, rng);
-        let wordCandidate = COMMON_WORDS[rand].val;
-        if (numberAddOn) {
-          wordCandidate = wordCandidate + generateRandomNumChras(1, 2, rng);
-        }
-        if (symbolAddOn) {
-          wordCandidate = wordCandidate + generateRandomSymbolChras(1, 1, rng);
-        }
-        EnglishWordList.push({ key: wordCandidate, val: wordCandidate });
-      }
-      return EnglishWordList;
-    }
-
-    // hard — select from random-words wordList with seeded RNG for determinism
-    const filteredHardWords = hardWordList.filter((w) => w.length <= 7);
-    const words = [];
-    for (let i = 0; i < wordsCount; i++) {
-      const rand = randomIntFromRange(0, filteredHardWords.length - 1, rng);
-      let wordCandidate = filteredHardWords[rand];
-      if (numberAddOn) {
-        wordCandidate = wordCandidate + generateRandomNumChras(1, 2, rng);
-      }
-      if (symbolAddOn) {
-        wordCandidate = wordCandidate + generateRandomSymbolChras(1, 1, rng);
-      }
-      words.push({ key: wordCandidate, val: wordCandidate });
-    }
-    return words;
+    return generateWordsFromBank(
+      WORD_BANK_BY_MODE[ENGLISH_MODE][difficulty],
+      wordsCount,
+      numberAddOn,
+      symbolAddOn,
+      rng
+    );
   }
   return ["something", "went", "wrong"];
 };
@@ -72,61 +108,13 @@ const chineseWordsGenerator = (
   rng
 ) => {
   if (languageMode === CHINESE_MODE) {
-    if (difficulty === DEFAULT_DIFFICULTY) {
-      const ChineseWordList = [];
-      for (let i = 0; i < DEFAULT_WORDS_COUNT; i++) {
-        const rand = randomIntFromRange(0, 5000, rng);
-        if (COMMON_CHINESE_WORDS[rand] && COMMON_CHINESE_WORDS[rand].val) {
-          let wordCandidateKey = COMMON_CHINESE_WORDS[rand].key;
-          let wordCandidateVal = COMMON_CHINESE_WORDS[rand].val;
-          if (numberAddOn) {
-            const generatedNumber = generateRandomNumChras(1, 2, rng);
-            wordCandidateKey = wordCandidateKey + generatedNumber;
-            wordCandidateVal = wordCandidateVal + generatedNumber;
-          }
-          if (symbolAddOn) {
-            const generatedSymbol = generateRandomSymbolChras(1, 1, rng);
-            wordCandidateKey = wordCandidateKey + generatedSymbol;
-            wordCandidateVal = wordCandidateVal + generatedSymbol;
-          }
-
-          ChineseWordList.push({
-            key: wordCandidateKey,
-            val: wordCandidateVal,
-          });
-        }
-      }
-
-      return ChineseWordList;
-    }
-
-    const ChineseIdiomsList = [];
-    for (let i = 0; i < DEFAULT_WORDS_COUNT; i++) {
-      const rand = randomIntFromRange(0, 5000, rng);
-      if (
-        COMMON_CHINESE_IDIOMS_WORDS[rand] &&
-        COMMON_CHINESE_IDIOMS_WORDS[rand].val
-      ) {
-        let wordCandidateKey = COMMON_CHINESE_IDIOMS_WORDS[rand].key;
-        let wordCandidateVal = COMMON_CHINESE_IDIOMS_WORDS[rand].val;
-        if (numberAddOn) {
-          const generatedNumber = generateRandomNumChras(1, 2, rng);
-          wordCandidateKey = wordCandidateKey + generatedNumber;
-          wordCandidateVal = wordCandidateVal + generatedNumber;
-        }
-        if (symbolAddOn) {
-          const generatedSymbol = generateRandomSymbolChras(1, 1, rng);
-          wordCandidateKey = wordCandidateKey + generatedSymbol;
-          wordCandidateVal = wordCandidateVal + generatedSymbol;
-        }
-        ChineseIdiomsList.push({
-          key: wordCandidateKey,
-          val: wordCandidateVal,
-        });
-      }
-    }
-
-    return ChineseIdiomsList;
+    return generateWordsFromBank(
+      WORD_BANK_BY_MODE[CHINESE_MODE][difficulty],
+      DEFAULT_WORDS_COUNT,
+      numberAddOn,
+      symbolAddOn,
+      rng
+    );
   }
 };
 


### PR DESCRIPTION
1. 词组生成器的标号限制换成了变量，不是硬编码。之前的代码在chinese hard下续词会因为错误的边界判断导致续词变少很多，现在不存在了。现在所有模式的生成代码都统一了，因为边界用一个变量来表示
2. chinese 续词之后存在光标消失问题，是因为显示逻辑有问题，现在换上了和english一样的逻辑，不会消失了
3. chinese续词之后存在拼音覆写上层、汉字不变、输入错位的问题，是因为索引少了startIndex，现在逻辑和english对齐了，可以正常续词。

已知问题：由于渲染机制&生成机制，偶尔会出现当前输入行跑到第三行，然后再跳回第二行的问题